### PR TITLE
💄 Design: 전역 디자인 토큰(theme.css) 도입 및 화면 디자인 통일

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /* Theme variables */
+import './theme.css';
 import Mypage from './pages/Mypage';
 import Email from './pages/EmailInquiry';
 import AdminHome from './pages/AdminHome';

--- a/src/components/ListContainer.css
+++ b/src/components/ListContainer.css
@@ -2,152 +2,209 @@
 
 /* 삭제요청 버튼 영역 */
 .delete-request-area {
-  margin-top: 8px;
+  margin-top: 10px;
 }
 .delete-request-btn {
-  --padding-start: 8px;
-  --padding-end: 8px;
+  --padding-start: 10px;
+  --padding-end: 10px;
+  --border-radius: var(--radius-pill);
+  --border-width: 1px;
   font-size: 12px;
+  font-weight: 600;
   margin: 0;
+  text-transform: none;
 }
 
 .announcement-section {
-  /* width: 680px; */ /* 고정 너비 대신 */
-  width: 100%; /* 부모 너비를 따르되 */
-  max-width: 680px; /* 최대 너비를 680px로 제한 */
-  /* 필요하다면 가운데 정렬 */
+  width: 100%;
+  max-width: 680px;
   margin-left: auto;
   margin-right: auto;
 }
 
 .badge {
   background-color: rgba(255, 255, 255, 0.652);
-  color: black; /* 글자 색상 */
+  color: var(--text-strong);
   padding: 5px 10px;
   border-radius: 5px;
 }
 
 li {
-  margin-bottom: 10px; /* 아래쪽에 10px 간격을 추가 */
+  margin-bottom: 10px;
 }
 
+/* 회사 필터: 알약형 칩 버튼 */
 .button-section {
   display: flex;
-  flex-wrap: wrap; /* 버튼이 화면 크기에 맞춰 줄바꿈 가능 */  
-  margin-bottom: 20px; /* 버튼 아래 여백 */
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 20px;
 }
 
-.button-section IonButton {
-  flex: 1 1 45%; /* 버튼을 2개씩 줄 바꿈하고, 최대 너비를 45%로 설정 */
-  min-width: 100px; /* 최소 너비 설정 */
+.button-section ion-button {
+  flex: 0 0 auto;
+  min-width: auto;
+  margin: 0;
+  height: 36px;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: -0.01em;
+  --border-radius: var(--radius-pill);
+  --padding-start: 16px;
+  --padding-end: 16px;
+  --box-shadow: none;
+}
+
+/* 비활성(회색) 칩 */
+.button-section ion-button[color="medium"] {
+  --background: var(--surface);
+  --background-hover: var(--surface-field);
+  --background-activated: var(--surface-field);
+  --color: var(--text-secondary);
+  --border-width: 1px;
+  --border-style: solid;
+  --border-color: var(--border);
+}
+
+/* 활성(선택) 칩 */
+.button-section ion-button[color="primary"] {
+  --background: var(--brand-primary);
+  --background-hover: var(--brand-primary-pressed);
+  --background-activated: var(--brand-primary-pressed);
+  --color: #ffffff;
 }
 
 .card-container {
   display: flex;
-  flex-direction: column; /* 세로 방향으로 배치 */
+  flex-direction: column;
+  gap: 12px;
   margin-top: 20px;
 }
 
 .job-card {
-  border: 1px solid #ddd;
-  border-radius: 8px; /* 모서리 둥글게 유지 */
-  padding: 0; /* 패딩 제거하여 꽉 차게 */
-  margin: 8px 0; /* 위아래 여백 추가 */
-  width: 100%; /* 카드의 너비를 100%로 설정 */
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  display: flex; /* 카드 내부에서 왼쪽과 오른쪽 정렬 */
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  background-color: var(--surface);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  overflow: hidden;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
+.job-card:hover {
+  box-shadow: var(--shadow-card-hover);
+  transform: translateY(-2px);
+}
+
+/* 회사 컬러 스트립 */
 .left-area {
-  background-color: #f0f0f0; /* 배경색 */
-  padding: 10px;
-  width: 10%; /* 왼쪽 영역 너비 */
-  border-top-left-radius: 8px; /* 모서리 둥글게 */
-  border-bottom-left-radius: 8px; /* 모서리 둥글게 */
+  background-color: var(--surface-field);
+  padding: 0;
+  width: 6px;
+  flex-shrink: 0;
+  border-radius: 0;
 }
 
 .right-area {
-  width: 90%; /* 오른쪽 영역 너비 */
-  padding: 16px; /* 오른쪽 영역 패딩 추가 */
-  border-top-right-radius: 8px; /* 모서리 둥글게 */
-  border-bottom-right-radius: 8px; /* 모서리 둥글게 */
+  flex: 1;
+  width: auto;
+  padding: 18px 20px;
+  border-radius: 0;
 }
 
 .job-card h3 {
-  font-size: 18px;
-  margin-bottom: 8px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-strong);
+  margin: 0 0 6px;
   display: block;
+  line-height: 1.45;
 }
 
 .job-card p {
-  margin: 4px 0;
+  margin: 4px 0 10px;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.5;
 }
 
 .job-card a {
-  color: #007bff;
+  display: inline-block;
+  color: var(--brand-primary);
+  background-color: var(--brand-primary-tint);
   text-decoration: none;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  transition: background-color 0.15s ease;
+}
+
+.job-card a:hover {
+  background-color: #d7e9ff;
 }
 
 /* 반응형 디자인 */
 @media (max-width: 768px) {
   .button-section {
-    flex-direction: row; /* 모바일에서 가로 방향으로 나열 */
-    justify-content: space-between; /* 버튼 사이의 공간을 균등하게 분배 */
-    gap: 1px; /* 버튼 간의 간격 줄이기 */
-    margin-bottom: -20px;
+    gap: 6px;
+    margin-bottom: 4px;
   }
 
-  .left-area {
-    width: 10%; /* 모바일에서 왼쪽 영역 너비 조정 */
-  }
-
-  .right-area {
-    width: 90%; /* 모바일에서 오른쪽 영역 너비 조정 */
-  }
-}
-
-@media (min-width: 769px) {
-  .left-area {
-    width: 10%; /* 데스크탑에서 왼쪽 영역 고정 너비 */
+  .button-section ion-button {
+    height: 32px;
+    font-size: 13px;
+    --padding-start: 12px;
+    --padding-end: 12px;
   }
 
   .right-area {
-    width: 90%; /* 데스크탑에서 오른쪽 영역 고정 너비 */
+    padding: 14px 16px;
   }
 }
 
 .search-section {
-  margin-bottom: 20px;
+  margin-bottom: 12px;
   width: 100%;
 }
 
 .custom-searchbar {
-  --background: #ffffff;
-  --border-radius: 8px;
-  --box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  --placeholder-color: #666;
-  --icon-color: #666;
+  --background: var(--surface);
+  --border-radius: var(--radius-md);
+  --box-shadow: none;
+  --placeholder-color: var(--text-muted);
+  --icon-color: var(--text-muted);
+  --color: var(--text-strong);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0;
   max-width: 100%;
 }
 
 .no-data-message {
   text-align: center;
-  font-size: 18px;
-  color: #666;
-  padding: 20px;
+  font-size: 15px;
+  color: var(--text-muted);
+  padding: 48px 20px;
+  background-color: var(--surface);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
 }
 
 .badge-new {
-  display: inline-block;   /* 인라인 옆에 안정적으로 위치 */
-  margin-left: 5px;
-  margin-top: 6px;
-  padding: 2px 6px;
-  font-size: 12px;
+  display: inline-block;
+  margin-left: 6px;
+  padding: 3px 8px;
+  font-size: 11px;
   font-weight: 700;
-  color: #fff;
-  background-color: #ff3b30;
-  border-radius: 10px;
+  color: var(--danger);
+  background-color: var(--danger-tint);
+  border-radius: var(--radius-pill);
   line-height: 1;
-  vertical-align: text-top; /* 또는 middle */
-  white-space: nowrap;      /* NEW 단어 자체는 줄바꿈 금지 */
+  vertical-align: text-top;
+  white-space: nowrap;
 }

--- a/src/pages/Detail.css
+++ b/src/pages/Detail.css
@@ -2,12 +2,26 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 16px;
+  padding: 24px 16px;
   height: 100%;
+  background-color: var(--surface-bg);
+  box-sizing: border-box;
 }
+
+.detail-container h1 {
+  font-size: 22px;
+  font-weight: 700;
+}
+
 .detail-content {
   margin: 0 auto;
   width: 43%;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 20px;
+  box-sizing: border-box;
 }
 
 .d-flex {
@@ -24,6 +38,10 @@
     flex-direction: column;
     align-items: flex-start;
   }
+
+  .detail-content {
+    width: 100%;
+  }
 }
 
 .map-container {
@@ -32,6 +50,9 @@
   margin: 20px auto;
   display: flex;
   justify-content: left;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border);
 }
 
 .comment-section {
@@ -52,8 +73,13 @@
 }
 
 .small-button {
-  font-size: 10px; /* 텍스트 크기 */
-  padding: 4px 8px; /* 버튼 내부 여백 */
-  height: 20px; /* 버튼 높이 */
+  font-size: 11px; /* 텍스트 크기 */
+  height: 24px; /* 버튼 높이 */
   line-height: 1; /* 텍스트 줄 높이 */
+  text-transform: none;
+  font-weight: 600;
+  --border-radius: var(--radius-pill);
+  --box-shadow: none;
+  --padding-start: 10px;
+  --padding-end: 10px;
 }

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -1,104 +1,165 @@
 /* Home.css */
-:root {
-  --ion-background-color: #ffffff; /* 흰색 배경 */
-  --ion-text-color: #333333; /* 어두운 회색 텍스트 */
-  --ion-border-color: #cccccc; /* 경계 색상 */
-}
 
 .container {
   display: flex;
   justify-content: center;
   width: 100%;
-  min-height: 100vh; /* 전체 화면 높이 */
+  min-height: 100vh;
   flex-direction: column; /* 기본적으로 세로 방향으로 쌓이도록 설정 */
+  gap: 20px;
+  padding: 20px;
+  box-sizing: border-box;
+  background-color: var(--surface-bg);
 }
 
 .left-aside, .right-aside {
-  width: 16%; /* 사이드바 너비 */
+  width: 240px;
+  flex-shrink: 0;
   padding: 20px;
-  background-color: #f4f4f4; /* 사이드바 배경색 */
-  border-radius: 8px; /* 모서리 둥글게 */
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 그림자 효과 */
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  align-self: flex-start;
+  position: sticky;
+  top: 20px;
 }
 
 .left-aside h2, .right-aside h2 {
-  margin-bottom: 10px;
-  color: #333333; /* 제목 색상 */
+  margin: 0 0 12px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-strong);
 }
 
 .content {
-  flex-grow: 1; /* 콘텐츠가 가능한 최대 너비를 차지하게 함 */
-  padding: 20px;
-  max-width: 800px; /* 콘텐츠 최대 너비 */
-  background-color: #ffffff; /* 콘텐츠 배경색 */
-  border-radius: 8px; /* 모서리 둥글게 */
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* 그림자 효과 */
-  color: #333333; /* 콘텐츠 텍스트 색상 */
+  flex-grow: 1;
+  padding: 0;
+  max-width: 800px;
+  background-color: transparent;
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--text-body);
 }
 
-/* 새로 추가되는 input 스타일 */
-/* 경력 입력 필드에 적용할 클래스 */
+/* 직군 토글 */
+.category-toggle {
+  display: block;
+  cursor: pointer;
+  color: var(--text-strong);
+  font-weight: 600;
+  font-size: 14px;
+  padding: 8px 10px;
+  margin: 0 -10px;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.category-toggle:hover {
+  background-color: var(--surface-field);
+  color: var(--brand-primary);
+}
+
+/* 경력 입력 필드 */
 .experience-input {
-  width: 50px;
+  width: 52px;
   text-align: center;
-  vertical-align: middle; /* 텍스트와 체크박스 세로 정렬 맞추기 */
-  background-color: white; /* 배경색을 흰색으로! */
-  color: black;           /* 글자색을 검은색으로! */
-  border: 1px solid #ccc; /* 테두리도 명확하게! */
-  border-radius: 4px;     /* 모서리 둥글게 */
-  padding: 1px 5px;           /* 내부 여백 */
-  /* margin-left와 margin-right는 인라인 스타일로 유지하거나,
-     부모 요소의 flex/grid 속성을 이용해 간격 조절 */
+  vertical-align: middle;
+  background-color: var(--surface-field);
+  color: var(--text-strong);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 4px 6px;
+  font-size: 13px;
+  transition: border-color 0.15s ease;
+}
+
+.experience-input:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+  background-color: var(--surface);
 }
 
 .rc-slider-mark-text {
-  white-space: nowrap; /* <-- 이 속성을 추가! */
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* rc-slider 테마 컬러 */
+.rc-slider-track {
+  background-color: var(--brand-primary);
+}
+.rc-slider-handle {
+  border-color: var(--brand-primary);
+}
+.rc-slider-handle:hover,
+.rc-slider-handle:active,
+.rc-slider-handle:focus,
+.rc-slider-handle-dragging {
+  border-color: var(--brand-primary-pressed) !important;
+  box-shadow: 0 0 0 4px rgba(49, 130, 246, 0.2) !important;
+}
+.rc-slider-dot-active {
+  border-color: var(--brand-primary);
 }
 
 input[type="checkbox"] {
-  margin-right: 10px; /* 체크박스와 레이블 간격 */
+  margin-right: 8px;
+  accent-color: var(--brand-primary);
+  width: 15px;
+  height: 15px;
+  vertical-align: middle;
 }
 
 label {
-  font-weight: bold; /* 레이블 강조 */
-  color: #333333; /* 레이블 텍스트 색상 */
-  cursor: pointer; /* 커서 포인터로 변경 */
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
 }
+
 .category-list {
-  margin-top: 10px;  
+  margin: 4px 0 10px;
+  padding-left: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
+
 .mySwiper {
-  width: 61%; /* Swiper의 너비를 100%로 설정 */
-  height: auto; /* 자동 높이 설정 */
+  width: 61%;
+  height: auto;
 }
 
 .mySwiper img {
-  width: 100%; /* 이미지의 너비를 100%로 설정하여 전체 너비에 맞춤 */
-  height: auto; /* 비율에 맞게 높이 자동 조정 */
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-lg);
 }
 
 /* 반응형 디자인 */
 @media (min-width: 768px) {
   .mySwiper {
-    width: 66%; /* Swiper의 너비를 100%로 설정 */
-    height: 28%; /* 자동 높이 설정 */
+    width: 66%;
+    height: 28%;
   }
   .container {
     flex-direction: row; /* 데스크탑에서는 가로 방향으로 나열 */
   }
   .left-aside {
     display: block; /* 데스크탑에서는 표시 */
-  }  
+  }
 }
 
 @media (max-width: 767px) {
   .mySwiper {
-    width: 100%; /* Swiper의 너비를 100%로 설정 */
-    height: auto; /* 자동 높이 설정 */
+    width: 100%;
+    height: auto;
   }
   .container {
-    margin-top: -6px; /* Swiper와 container 사이의 간격 조정 */    
     justify-content: flex-start;
+    padding: 12px;
   }
   .left-aside {
     display: none; /* 모바일에서는 기본적으로 숨김 */

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -226,7 +226,7 @@ const Home: React.FC = () => {
                   <div key={categoryData.id}>
                     <span
                       onClick={() => toggleCategories(categoryData.name)}
-                      style={{ cursor: 'pointer', color: '#007bff', fontWeight: 'bold' }}
+                      className="category-toggle"
                     >
                       {categoryData.name}
                     </span>

--- a/src/pages/Mypage.css
+++ b/src/pages/Mypage.css
@@ -1,29 +1,70 @@
 .mypage-container {
   display: flex;
+  gap: 20px;
+  padding: 20px;
+  background-color: var(--surface-bg);
+  min-height: 100%;
+  box-sizing: border-box;
 }
 
 .sidebar {
   width: 200px; /* 사이드바의 너비 */
-  padding: 10px;
+  padding: 12px;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  align-self: flex-start;
+}
+
+.sidebar ion-item {
+  --background: transparent;
+  --color: var(--text-secondary);
+  --border-color: transparent;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  font-weight: 500;
 }
 
 .content {
   flex: 1; /* 남은 공간을 차지 */
-  padding: 20px;
+  padding: 24px;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.content h2 {
+  margin-top: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.content h4 {
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--text-muted);
 }
 
 .active {
-  background-color: #007bff; /* 활성화된 메뉴 배경색 */
-  color: rgb(0, 0, 0); /* 활성화된 메뉴 텍스트 색상 */
+  --background: var(--brand-primary-tint);
+  background-color: var(--brand-primary-tint);
+  --color: var(--brand-primary);
+  color: var(--brand-primary);
+  font-weight: 700;
 }
 
 .career-button {
     /* 버튼 좌우 마진을 주어 서로 너무 붙지 않게 */
-    margin: 5px; /* 모든 방향으로 마진 */
+    margin: 4px;
     min-width: 60px; /* 버튼의 최소 너비 설정 (텍스트 길이에 따라 조절) */
-    /* 필요하다면 폰트 크기나 패딩도 조절 가능 */
-    --padding-start: 12px;
-    --padding-end: 12px;
+    text-transform: none;
+    font-weight: 600;
+    --border-radius: var(--radius-pill);
+    --box-shadow: none;
+    --padding-start: 14px;
+    --padding-end: 14px;
     --padding-top: 8px;
     --padding-bottom: 8px;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,101 @@
+/* =========================================
+   전역 디자인 토큰 & Ionic 테마 오버라이드
+   화면별 CSS는 여기 정의된 변수를 사용한다.
+   ========================================= */
+/* Ionic의 .ion-page / ion-content(slot) 경계에서 커스텀 프로퍼티 상속이
+   끊기는 경우가 있어 해당 경계 안쪽에도 토큰을 다시 선언한다. */
+:root,
+.ion-page,
+ion-content > * {
+  /* Brand */
+  --brand-primary: #3182f6;
+  --brand-primary-pressed: #1b64da;
+  --brand-primary-tint: #e8f3ff;
+
+  /* Text */
+  --text-strong: #191f28;
+  --text-body: #333d4b;
+  --text-secondary: #4e5968;
+  --text-muted: #8b95a1;
+  --text-disabled: #b0b8c1;
+
+  /* Surface */
+  --surface: #ffffff;
+  --surface-bg: #f7f8fa;
+  --surface-field: #f2f4f6;
+  --border: #e5e8eb;
+  --divider: #f2f4f6;
+
+  /* Semantic */
+  --danger: #f04452;
+  --danger-tint: #fdecee;
+  --success: #059669;
+  --success-tint: #d1fae5;
+
+  /* Shape & shadow */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-pill: 9999px;
+  --shadow-card: 0 2px 12px rgba(25, 31, 40, 0.06);
+  --shadow-card-hover: 0 6px 20px rgba(25, 31, 40, 0.1);
+
+  /* Ionic 테마 매핑 */
+  --ion-color-primary: #3182f6;
+  --ion-color-primary-rgb: 49, 130, 246;
+  --ion-color-primary-contrast: #ffffff;
+  --ion-color-primary-contrast-rgb: 255, 255, 255;
+  --ion-color-primary-shade: #1b64da;
+  --ion-color-primary-tint: #4690f7;
+
+  --ion-background-color: #f7f8fa;
+  --ion-text-color: #191f28;
+  --ion-border-color: #e5e8eb;
+  --ion-font-family: "Pretendard Variable", Pretendard, -apple-system,
+    BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI",
+    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+}
+
+body {
+  letter-spacing: -0.01em;
+  color: var(--text-body);
+}
+
+h1, h2, h3, h4 {
+  color: var(--text-strong);
+  letter-spacing: -0.02em;
+}
+
+/* ---------- 공통 헤더 ---------- */
+ion-header ion-toolbar {
+  --background: var(--surface);
+  --border-color: var(--border);
+  --color: var(--text-strong);
+}
+
+ion-header ion-title {
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+  color: var(--brand-primary);
+}
+
+ion-header ion-buttons ion-button {
+  --color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+/* ---------- 푸터 ---------- */
+ion-footer ion-toolbar {
+  --background: var(--surface);
+  --border-color: var(--border);
+}
+
+.footer-text {
+  display: block;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 4px 0;
+}


### PR DESCRIPTION
## 요약
- CSS 변수 기반 전역 디자인 토큰(`src/theme.css`) 신설: 브랜드 컬러 #3182F6, 뉴트럴, radius/그림자
- Ionic 테마 변수 매핑 + 공통 헤더/푸터 스타일 정리
- 홈: 필터 사이드바 카드형(sticky), 직군 토글 hover, 슬라이더/체크박스 브랜드 컬러
- 공고 리스트: 회사 필터 알약형 칩, 공고 카드 hover 효과, 회사 컬러 스트립(6px), NEW 뱃지/검색바 개선
- 상세/마이페이지/문의: 카드형 레이아웃, 활성 메뉴 색 대비 개선
- Ionic .ion-page / ion-content 경계에서 CSS 변수 상속이 끊기는 이슈 대응 선언 추가

## 검증
- CRA dev 서버 컴파일 정상 (경고는 기존 코드의 unused import 등)
- 브라우저에서 테마 변수/칩 버튼 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a consistent application-wide visual theme, including colors, typography, spacing, surfaces, borders, and shadows.
  * Added coordinated styling for headers, footers, buttons, filters, cards, search areas, and status badges.

* **Style**
  * Refined home, detail, list, and MyPage layouts with improved spacing, responsive behavior, and visual hierarchy.
  * Improved mobile presentation and interactive states, including hover, focus, and category toggle styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->