### PR TITLE
✨ Feat: NEW(오늘 등록) 공고를 목록 최상단에 정렬

### DIFF
--- a/src/components/ListContainer.tsx
+++ b/src/components/ListContainer.tsx
@@ -180,6 +180,13 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
     return matchesEmploymentType && matchesCareer && matchesCategory && matchesSearch;
   });
 
+  // 오늘 등록된 공고(NEW)를 최상위로. Array.prototype.sort는 안정 정렬이므로 나머지 순서는 유지된다.
+  const sortedProducts = [...filteredProducts].sort((a, b) => {
+    const aIsNew = isTodayInsertDts(a.insertDts) ? 1 : 0;
+    const bIsNew = isTodayInsertDts(b.insertDts) ? 1 : 0;
+    return bIsNew - aIsNew;
+  });
+
   const handleClick = async (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>, 
     annoId: number | string,
@@ -251,8 +258,8 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
         </div>
 
         <div className="card-container">
-          {filteredProducts.length > 0 ? (
-            filteredProducts.map((item: Job_mst) => {
+          {sortedProducts.length > 0 ? (
+            sortedProducts.map((item: Job_mst) => {
               const companyKey = Object.keys(companyColors).find(key => 
                 item.companyCd && item.companyCd.toUpperCase().includes(key.toUpperCase())
               );


### PR DESCRIPTION
## 요약
- 공고 목록을 렌더링 직전에 안정 정렬(`sortedProducts`)하여, 오늘 등록된 NEW 공고를 최상단으로 이동
- `isTodayInsertDts(insertDts)` 기준으로 NEW 여부 판단
- 안정 정렬이므로 NEW 그룹/일반 그룹 각각의 기존 순서는 유지

## 검증
- 로컬 DB에서 네이버 공고 일부를 오늘 날짜로 변경 후, 해당 공고가 NEW 뱃지와 함께 목록 0·1번 위치에 노출됨을 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly added jobs now appear at the top of the job list for easier visibility.

* **Bug Fixes**
  * Ensured the displayed job cards consistently follow the updated sorting order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->