### PR TITLE
✨ Feat: dodrambio KV 캐시로 공고/카테고리 API 응답 6시간 캐싱

### DIFF
--- a/src/common/kvCache.ts
+++ b/src/common/kvCache.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+
+/**
+ * dodrambio KV 캐시 (https://dodrambio.com/api/kv)
+ *
+ * cloudtype 서버는 잠들어 있다가 깨어나는 데 시간이 걸리므로,
+ * 자주 바뀌지 않는 공개 데이터(공고 목록, 카테고리)는 dodrambio 를
+ * Redis 처럼 써서 응답을 얹어두고 재사용한다.
+ *
+ * - 캐시 미스(404)나 KV 서버 장애 시에는 원본 API 로 그대로 폴백한다.
+ * - 로컬 개발에서는 캐시를 타지 않는다 (운영 캐시 오염 방지).
+ * - 사용자별/상태변화 데이터(상세의 좋아요·댓글, 삭제요청 목록 등)는 절대 캐싱하지 말 것.
+ */
+const KV_BASE = 'https://dodrambio.com/api/kv';
+
+/** 채용공고는 자주 바뀌지 않으므로 6시간 캐싱 */
+const TTL_SECONDS = 6 * 60 * 60;
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export async function cachedGet<T>(key: string, originUrl: string, params?: Record<string, string>): Promise<T> {
+  const kvUrl = `${KV_BASE}/${key}`;
+
+  if (isProduction) {
+    try {
+      const hit = await axios.get<T>(kvUrl);
+      return hit.data;
+    } catch {
+      // 404(미스)든 KV 장애든 원본으로 폴백
+    }
+  }
+
+  const response = await axios.get<T>(originUrl, { params });
+
+  if (isProduction) {
+    // 저장은 베스트에포트 — 실패해도 사용자 흐름에 영향 없음
+    axios
+      .put(`${kvUrl}?ttl=${TTL_SECONDS}`, JSON.stringify(response.data), {
+        headers: { 'Content-Type': 'application/json' },
+      })
+      .catch(() => {});
+  }
+
+  return response.data;
+}

--- a/src/components/ListContainer.tsx
+++ b/src/components/ListContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 import API_URL from "../config";
+import { cachedGet } from '../common/kvCache';
 import './ListContainer.css';
 import { IonButton, IonSearchbar } from '@ionic/react';
 import { Filters } from '../pages/Home';
@@ -42,18 +43,16 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
       }
 
       try {
-        const response: AxiosResponse<Job_mst[]> = await axios.get<Job_mst[]>(`${API_URL}/api/list`, {
-          params: { company },
-        });
+        const data = await cachedGet<Job_mst[]>(`nklcb:list:${company}`, `${API_URL}/api/list`, { company });
 
-        if (Array.isArray(response.data)) {
-          setProducts(response.data);
+        if (Array.isArray(data)) {
+          setProducts(data);
           setCache((prevCache) => ({
             ...prevCache,
-            [company]: response.data,
+            [company]: data,
           }));
         } else {
-          console.error('Unexpected response format:', response.data);
+          console.error('Unexpected response format:', data);
         }
       } catch (error) {
         console.error('Error fetching data:', error);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import API_URL from "../config";
+import { cachedGet } from '../common/kvCache';
 import { IonButton, IonButtons, IonContent, IonFooter, IonHeader, IonPage, IonText, IonTitle, IonToolbar } from '@ionic/react';
 import ListContainer from '../components/ListContainer';
 import { Helmet } from 'react-helmet';
@@ -52,11 +52,11 @@ const Home: React.FC = () => {
   useEffect(() => {
     const fetchCategories = async () => {
       try {
-        const response = await axios.get(`${API_URL}/api/category/list`); // API 엔드포인트 수정
-        setCategoriesData(response.data);
+        const data = await cachedGet<CategoryMst[]>('nklcb:category:list', `${API_URL}/api/category/list`);
+        setCategoriesData(data);
 
         // 필터 초기화
-        const initialCategoriesFilter = response.data.reduce((acc: Record<string, string[]>, category: CategoryMst) => {
+        const initialCategoriesFilter = data.reduce((acc: Record<string, string[]>, category: CategoryMst) => {
           acc[category.name.toLowerCase()] = [];
           return acc;
         }, {});

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import axios from 'axios';
+import { cachedGet } from '../common/kvCache';
 import { 
   IonPage, 
   IonContent, 
@@ -64,10 +64,10 @@ const Mypage: React.FC = () => {
           }
         }
         
-        const allJobRolesData = await axios.get(`${API_URL}/api/category/list`);
+        const allJobRolesData = await cachedGet<any>('nklcb:category:list', `${API_URL}/api/category/list`);
 
-        if (allJobRolesData.data) {
-          setAvailableJobRoles(allJobRolesData.data);
+        if (allJobRolesData) {
+          setAvailableJobRoles(allJobRolesData);
         }
         
 


### PR DESCRIPTION
## 개요
cloudtype 서버가 잠들어 있다 깨는 동안 첫 로딩이 느린 문제를 완화합니다.
dodrambio 서버를 Redis처럼 쓰는 KV 캐시(`https://dodrambio.com/api/kv`)에 공개 API 응답을 6시간 캐싱합니다.

## 변경사항
- `src/common/kvCache.ts` 추가 — KV 조회 → 미스 시 원본 호출 → 결과 PUT 저장 (best-effort)
- 공고 목록 `/api/list?company=X`, 직군 카테고리 `/api/category/list` 에 캐시 적용
- 사용자별/상태변화 API(상세 좋아요·댓글, 삭제요청 목록)는 캐싱하지 않음
- 로컬 개발(NODE_ENV !== production)에서는 캐시를 타지 않음
- 캐시 미스·KV 장애 시 원본 API로 그대로 폴백

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Added caching for job listings, categories, and job-role data to improve loading speed and reduce repeated network requests.
  - Cached data is refreshed automatically when unavailable or outdated.
  - The app continues loading data normally if cached data cannot be retrieved.
- **Bug Fixes**
  - Improved resilience when the caching service is unavailable, ensuring pages remain usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->