### PR TITLE
✨ Feat: 앱 진입 시 cloudtype 서버 워밍업 핑

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { IonReactRouter } from '@ionic/react-router';
 import Home from './pages/Home';
 import { AuthProvider } from './common/AuthContextType';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import axios from 'axios';
+import API_URL from './config';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -33,6 +35,13 @@ import AdminJobDeleteRequests from './pages/AdminJobDeleteRequests';
 setupIonicReact();
 const queryClient = new QueryClient();
 const App: React.FC = () => {
+
+  useEffect(() => {
+    // cloudtype 서버 워밍업 — 목록/카테고리는 dodrambio KV 캐시가 응답하므로
+    // 원본 서버가 잠들어 있기 쉽다. 방문자가 캐시된 목록을 보는 동안 미리 깨워두면
+    // 로그인 등 캐싱 불가능한 실시간 API가 콜드스타트 없이 바로 응답한다.
+    axios.get(`${API_URL}/api/job-delete-requests/pending-ids`).catch(() => undefined);
+  }, []);
 
   return (
     <IonApp>


### PR DESCRIPTION
KV 캐시 도입으로 목록 조회가 원본 서버를 깨우지 않게 되어,
로그인 등 실시간 API 호출 시점에 콜드스타트를 맞을 확률이 높아짐.
방문자가 캐시된 목록을 보는 동안 서버를 미리 깨워둔다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added an automatic background request when the app loads to prepare job deletion request data.
  * Improved resilience by allowing the app to continue loading if the request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->