### PR TITLE
✨ Feat: 로그인/회원가입 화면 — PC 모달, 모바일 페이지, 카카오 로그인 통합

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import '@ionic/react/css/display.css';
 /* Theme variables */
 import './theme.css';
 import Mypage from './pages/Mypage';
+import Login from './pages/Login';
 import Email from './pages/EmailInquiry';
 import AdminHome from './pages/AdminHome';
 import AdminSubscriptions from './pages/AdminSubscriptions';
@@ -51,6 +52,7 @@ const App: React.FC = () => {
             <IonRouterOutlet>
               <Route path='/' component={Home} exact={true} />
               <Route path='/mypage' component={Mypage} exact={true} />
+              <Route path='/login' component={Login} exact={true} />
               <Route path='/email' component={Email} exact={true} />
               <Route path='/admin' component={AdminHome} exact={true} />
               <Route path='/admin/subscriptions' component={AdminSubscriptions} exact={true} />

--- a/src/common/AuthContextType.tsx
+++ b/src/common/AuthContextType.tsx
@@ -1,31 +1,56 @@
 import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+import { AuthResponse } from './authApi';
+
 interface User {
   name: string; // 예시로 사용자 이름을 포함
+  userId?: string; // "kakao@{id}" 또는 "local@{id}". 토큰 재발급에 필요하다.
 }
 
 interface AuthContextType {
   isLoggedIn: boolean;
   user: User | null;
-  login: (token: string, userInfo: User) => void;
+  /** 카카오/자체 로그인 공통 성공 처리. 토큰과 사용자 정보를 저장하고 로그인 상태로 바꾼다. */
+  login: (auth: AuthResponse) => void;
   logout: () => void;
 }
+
+const USER_STORAGE_KEY = 'authUser';
+
+/** 새로고침 후에도 사용자 정보가 유지되도록 localStorage 에서 복원한다. */
+const readStoredUser = (): User | null => {
+  const raw = localStorage.getItem(USER_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as User;
+  } catch {
+    return null;
+  }
+};
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
 
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(!!localStorage.getItem('jwtToken'));
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<User | null>(readStoredUser);
 
-  // 로그인 시 JWT 토큰을 로컬 스토리지에 저장하고 로그인 상태 업데이트
-  const login = (token: string, userInfo: User) => {
+  // 로그인 시 JWT 토큰과 사용자 정보를 로컬 스토리지에 저장하고 로그인 상태 업데이트
+  const login = (auth: AuthResponse) => {
+    const userInfo: User = { name: auth.nickname, userId: auth.userId };
+    localStorage.setItem('jwtToken', auth.token);
+    localStorage.setItem('refreshToken', auth.refreshToken);
+    localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(userInfo));
     setIsLoggedIn(true);
     setUser(userInfo);
   }
-  
+
   // 로그아웃 시 로컬 스토리지에서 JWT 토큰을 삭제하고 로그인 상태 업데이트
   const logout = () => {
     localStorage.removeItem('jwtToken');
+    localStorage.removeItem('refreshToken');
+    localStorage.removeItem(USER_STORAGE_KEY);
     setIsLoggedIn(false);
     setUser(null);
     window.location.href = '/'; // 메인 페이지로 이동

--- a/src/common/CommonHeader.tsx
+++ b/src/common/CommonHeader.tsx
@@ -1,18 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { IonHeader, IonToolbar, IonTitle, IonButtons, IonButton } from '@ionic/react';
 import { useHistory } from 'react-router-dom';
 import { useAuth } from '../common/AuthContextType';
-import KakaoLoginButton from '../components/KakoLoginButton';
+import useIsMobile from '../common/useIsMobile';
+import LoginModal from '../components/LoginModal';
 
 const CommonHeader: React.FC = () => {
   const history = useHistory();
   const { logout, isLoggedIn } = useAuth();
+  const isMobile = useIsMobile();
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   const handleTitleClick = () => {
     history.push('/');
   };
 
+  // PC 는 모달로 띄우고, 모바일은 화면이 좁아 별도 로그인 페이지로 이동한다.
+  const handleLoginClick = () => {
+    if (isMobile) {
+      history.push('/login');
+    } else {
+      setShowLoginModal(true);
+    }
+  };
+
   return (
+    <>
     <IonHeader>
       <IonToolbar>
         <IonTitle onClick={handleTitleClick} style={{ cursor: 'pointer' }}>네카라쿠배당토야</IonTitle>
@@ -24,11 +37,17 @@ const CommonHeader: React.FC = () => {
               <IonButton onClick={logout}>로그아웃</IonButton>
             </>
           ) : (
-            <KakaoLoginButton /> // 로그인하지 않은 경우 카카오 로그인 버튼 표시
+            // 이메일 로그인/회원가입과 카카오 로그인을 한 화면에서 고르게 한다
+            <IonButton onClick={handleLoginClick}>로그인</IonButton>
           )}
         </IonButtons>
       </IonToolbar>
     </IonHeader>
+    {/* 오버레이는 ion-header 안에 두면 Ionic 이 template 에 가둬 열리지 않는다. 헤더 밖에 둔다. */}
+    {!isMobile && (
+      <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+    )}
+    </>
   );
 };
 

--- a/src/common/UseTokenRefresh.ts
+++ b/src/common/UseTokenRefresh.ts
@@ -17,10 +17,17 @@ const UseTokenRefresh = () => {
       return;
     }
 
+    if (!user?.userId) {
+      console.log('userId is null');
+      logout();
+      return;
+    }
+
     try {
+      // 백엔드 RefreshRequest 는 { refreshToken, userVo: { userId } } 형태를 받는다.
       const tokenResponse = await axios.post(`${API_URL}/api/auth/refresh`, {
         refreshToken,
-        user
+        userVo: { userId: user.userId }
       }, {
         headers: {
           'Authorization': `Bearer ${refreshToken}`

--- a/src/common/authApi.ts
+++ b/src/common/authApi.ts
@@ -1,0 +1,60 @@
+// 자체 로그인/회원가입 API 호출. 백엔드 LocalAuthController(/api/auth/**) 와 짝을 이룬다.
+// 응답 형태는 카카오 로그인(/api/kakaoLogin)과 같아서 로그인 성공 처리를 한 곳에서 쓸 수 있다.
+import axios from 'axios';
+import API_URL from '../config';
+
+/** /api/auth/login, /api/auth/signup, /api/kakaoLogin 이 공통으로 돌려주는 형태 */
+export interface AuthResponse {
+  token: string;
+  refreshToken: string;
+  userId: string;
+  nickname: string;
+}
+
+/** 서버가 돌려준 사용자용 메세지를 꺼낸다. 없으면 기본 문구. */
+const messageOf = (error: unknown, fallback: string): string => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { message?: string } | undefined;
+    if (data?.message) {
+      return data.message;
+    }
+    if (!error.response) {
+      return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.';
+    }
+  }
+  return fallback;
+};
+
+export const login = async (email: string, password: string): Promise<AuthResponse> => {
+  try {
+    const res = await axios.post<AuthResponse>(`${API_URL}/api/auth/login`, { email, password });
+    return res.data;
+  } catch (error) {
+    throw new Error(messageOf(error, '로그인에 실패했습니다.'));
+  }
+};
+
+export const signup = async (
+  email: string,
+  password: string,
+  nickname: string
+): Promise<AuthResponse> => {
+  try {
+    const res = await axios.post<AuthResponse>(`${API_URL}/api/auth/signup`, { email, password, nickname });
+    return res.data;
+  } catch (error) {
+    throw new Error(messageOf(error, '회원가입에 실패했습니다.'));
+  }
+};
+
+/** 회원가입 화면의 이메일 중복 확인. 확인에 실패하면 가입 시도를 막지 않도록 false 로 본다. */
+export const emailExists = async (email: string): Promise<boolean> => {
+  try {
+    const res = await axios.get<{ exists: boolean }>(`${API_URL}/api/auth/email-exists`, {
+      params: { email },
+    });
+    return res.data.exists;
+  } catch (error) {
+    return false;
+  }
+};

--- a/src/common/useIsMobile.ts
+++ b/src/common/useIsMobile.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+/** 이 폭 이하를 모바일로 본다. Ionic 의 md breakpoint(768px)와 맞췄다. */
+const MOBILE_MAX_WIDTH = 768;
+
+const query = `(max-width: ${MOBILE_MAX_WIDTH}px)`;
+
+/**
+ * 모바일 폭인지 알려준다. 로그인은 PC 에서 모달, 모바일에서 /login 페이지로 열리므로
+ * 창 크기를 바꿔도 따라오도록 matchMedia 를 구독한다.
+ */
+const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState<boolean>(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const handleChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+
+    // Safari 13 이하는 addEventListener 를 지원하지 않아 addListener 로 대체한다.
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return isMobile;
+};
+
+export default useIsMobile;

--- a/src/components/KakaoLoginButton.css
+++ b/src/components/KakaoLoginButton.css
@@ -1,0 +1,35 @@
+/* 카카오 로그인 버튼. 카카오 브랜드 색은 고정값이라 토큰을 쓰지 않는다. */
+.kakao-login-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background-color: #fee500;
+  color: #3c1e1e;
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  padding: 0 16px;
+  height: 40px;
+  border: none;
+  border-radius: var(--radius-sm, 8px);
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.kakao-login-button:hover {
+  filter: brightness(0.96);
+}
+
+.kakao-login-button:active {
+  filter: brightness(0.92);
+}
+
+/* 로그인 폼 안에서 전체 너비로 쓸 때 */
+.kakao-login-button--block {
+  display: flex;
+  width: 100%;
+  height: 48px;
+  font-size: 16px;
+}

--- a/src/components/KakoLoginButton.tsx
+++ b/src/components/KakoLoginButton.tsx
@@ -1,15 +1,32 @@
 import React from 'react';
 import KakaoLogin from 'react-kakao-login';
 import { FaComment } from 'react-icons/fa';
-import axios from 'axios';
 import API_URL from '../config';
 import { useAuth } from '../common/AuthContextType';
+import { AuthResponse } from '../common/authApi';
+import './KakaoLoginButton.css';
 
-const KakaoLoginButton = () => {
+interface KakaoLoginButtonProps {
+    /** 버튼 문구. 로그인 화면에서는 "카카오로 로그인" 처럼 길게 쓴다. */
+    label?: string;
+    /** 로그인 폼 안에서 다른 버튼과 같은 너비로 놓을 때 사용 */
+    fullWidth?: boolean;
+    /** 로그인 성공 후 화면을 닫거나 이동시킬 때 사용 */
+    onSuccess?: () => void;
+    /** 로그인 실패를 화면에 보여줄 때 사용 */
+    onError?: (message: string) => void;
+}
+
+const KakaoLoginButton: React.FC<KakaoLoginButtonProps> = ({
+    label = 'Login',
+    fullWidth = false,
+    onSuccess,
+    onError,
+}) => {
     const { login } = useAuth();
-    
+
     const responseKakao = async (response: any) => {
-        
+
         try {
             const res = await fetch(`${API_URL}/api/kakaoLogin`, {
                 method: 'POST',
@@ -25,32 +42,36 @@ const KakaoLoginButton = () => {
                 throw new Error('Network response was not ok');
             }
 
-            const data = await res.json();
-            localStorage.setItem('jwtToken', data.token);
-            localStorage.setItem('refreshToken', data.refreshToken);
-            const userInfo = {
-                name: data.nickname,
-                userId: data.userId,
-            };
-            login(data, userInfo);
+            const data: AuthResponse = await res.json();
+            // 토큰/사용자 정보 저장은 AuthContext 가 자체 로그인과 동일하게 처리한다.
+            login(data);
+            onSuccess?.();
         } catch (error) {
             console.log('Error: ', error);
+            onError?.('카카오 로그인에 실패했습니다. 잠시 후 다시 시도해 주세요.');
         }
-       
+
     };
 
     return (
         <KakaoLogin
             token="b3851f460ed49a031b6c35cb808a1514"
             onSuccess={responseKakao}
-            onFail={(error: any) => console.error(error)}
+            onFail={(error: any) => {
+                console.error(error);
+                onError?.('카카오 로그인이 취소되었거나 실패했습니다.');
+            }}
             render={({ onClick }) => (
-                <button onClick={onClick} style={{ backgroundColor: '#fee500', color: '#3c1e1e', padding: '10px 20px', border: 'none', borderRadius: '4px', cursor: 'pointer' }}>
-                    <FaComment size={24} />
-                    Login
+                <button
+                    type="button"
+                    onClick={onClick}
+                    className={`kakao-login-button${fullWidth ? ' kakao-login-button--block' : ''}`}
+                >
+                    <FaComment size={18} />
+                    {label}
                 </button>
             )}
-        />            
+        />
     );
 };
 

--- a/src/components/LoginForm.css
+++ b/src/components/LoginForm.css
@@ -1,0 +1,91 @@
+/* 로그인/회원가입 폼. PC 모달과 모바일 /login 페이지가 공유한다.
+   색/모서리 값은 theme.css 의 토큰을 쓴다. */
+.login-form {
+  width: 100%;
+}
+
+/* ---------- 로그인 / 회원가입 탭 ---------- */
+.login-form__tabs {
+  display: flex;
+  gap: 4px;
+  background: var(--surface-field, #f2f4f6);
+  border-radius: var(--radius-sm, 8px);
+  padding: 4px;
+  margin-bottom: 20px;
+}
+
+.login-form__tab {
+  flex: 1;
+  height: 38px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm, 8px);
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-muted, #8b95a1);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.login-form__tab--active {
+  background: var(--surface, #ffffff);
+  color: var(--text-strong, #191f28);
+  box-shadow: var(--shadow-card, 0 2px 12px rgba(25, 31, 40, 0.06));
+}
+
+/* ---------- 입력 ---------- */
+.login-form__field {
+  border: 1px solid var(--border, #e5e8eb);
+  border-radius: var(--radius-sm, 8px);
+  padding: 2px 12px;
+  margin-bottom: 10px;
+  background: var(--surface, #ffffff);
+}
+
+.login-form__field ion-input {
+  --padding-start: 0;
+  --padding-end: 0;
+  --placeholder-color: var(--text-disabled, #b0b8c1);
+  --placeholder-opacity: 1;
+  font-size: 15px;
+}
+
+.login-form__error {
+  margin: 4px 0 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--danger, #f04452);
+}
+
+.login-form__submit {
+  margin: 6px 0 0;
+  --border-radius: var(--radius-sm, 8px);
+  height: 48px;
+  font-weight: 700;
+}
+
+/* ---------- 구분선 ---------- */
+.login-form__divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 20px 0 16px;
+  color: var(--text-muted, #8b95a1);
+  font-size: 12px;
+}
+
+.login-form__divider::before,
+.login-form__divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--divider, #f2f4f6);
+}
+
+.login-form__hint {
+  margin: 16px 0 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-muted, #8b95a1);
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,183 @@
+import React, { useState } from 'react';
+import { IonButton, IonInput, IonSpinner } from '@ionic/react';
+import { useAuth } from '../common/AuthContextType';
+import { login as loginApi, signup as signupApi, emailExists } from '../common/authApi';
+import KakaoLoginButton from './KakoLoginButton';
+import './LoginForm.css';
+
+type Mode = 'login' | 'signup';
+
+interface LoginFormProps {
+  /** 로그인/회원가입 성공 후 처리(모달 닫기, 페이지 이동 등) */
+  onSuccess?: () => void;
+}
+
+const MIN_PASSWORD_LENGTH = 8; // 백엔드 LocalAuthService 와 같은 기준
+
+/**
+ * 이메일+비밀번호 로그인/회원가입 폼. 아래에 기존 카카오 로그인 버튼을 함께 둔다.
+ * PC 는 LoginModal, 모바일은 /login 페이지에서 같은 폼을 쓴다.
+ */
+const LoginForm: React.FC<LoginFormProps> = ({ onSuccess }) => {
+  const { login } = useAuth();
+  const [mode, setMode] = useState<Mode>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const switchMode = (next: Mode) => {
+    setMode(next);
+    setError(null);
+    setPassword('');
+    setPasswordConfirm('');
+  };
+
+  /** 제출 전 클라이언트 검증. 문제가 없으면 null. */
+  const validate = (): string | null => {
+    if (!email.trim() || !password) {
+      return '이메일과 비밀번호를 입력해 주세요.';
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+      return '이메일 형식이 올바르지 않습니다.';
+    }
+    if (mode === 'signup') {
+      if (password.length < MIN_PASSWORD_LENGTH) {
+        return `비밀번호는 ${MIN_PASSWORD_LENGTH}자 이상으로 입력해 주세요.`;
+      }
+      if (password !== passwordConfirm) {
+        return '비밀번호가 서로 다릅니다.';
+      }
+    }
+    return null;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const invalid = validate();
+    if (invalid) {
+      setError(invalid);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      if (mode === 'signup') {
+        // 서버도 중복을 막지만, 먼저 확인해 주면 안내가 더 빠르다.
+        if (await emailExists(email.trim())) {
+          setError('이미 가입된 이메일입니다. 로그인해 주세요.');
+          return;
+        }
+        const auth = await signupApi(email.trim(), password, nickname.trim());
+        login(auth); // 가입 즉시 로그인 상태가 된다
+      } else {
+        const auth = await loginApi(email.trim(), password);
+        login(auth);
+      }
+      onSuccess?.();
+    } catch (err: any) {
+      setError(err?.message ?? '잠시 후 다시 시도해 주세요.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="login-form">
+      <div className="login-form__tabs" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'login'}
+          className={`login-form__tab${mode === 'login' ? ' login-form__tab--active' : ''}`}
+          onClick={() => switchMode('login')}
+        >
+          로그인
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={mode === 'signup'}
+          className={`login-form__tab${mode === 'signup' ? ' login-form__tab--active' : ''}`}
+          onClick={() => switchMode('signup')}
+        >
+          회원가입
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <div className="login-form__field">
+          <IonInput
+            type="email"
+            value={email}
+            placeholder="이메일"
+            autocomplete="email"
+            onIonInput={(e) => setEmail(e.detail.value ?? '')}
+          />
+        </div>
+
+        {mode === 'signup' && (
+          <div className="login-form__field">
+            <IonInput
+              value={nickname}
+              placeholder="닉네임 (생략하면 이메일 앞부분을 씁니다)"
+              autocomplete="nickname"
+              onIonInput={(e) => setNickname(e.detail.value ?? '')}
+            />
+          </div>
+        )}
+
+        <div className="login-form__field">
+          <IonInput
+            type="password"
+            value={password}
+            placeholder={mode === 'signup' ? `비밀번호 (${MIN_PASSWORD_LENGTH}자 이상)` : '비밀번호'}
+            autocomplete={mode === 'signup' ? 'new-password' : 'current-password'}
+            onIonInput={(e) => setPassword(e.detail.value ?? '')}
+          />
+        </div>
+
+        {mode === 'signup' && (
+          <div className="login-form__field">
+            <IonInput
+              type="password"
+              value={passwordConfirm}
+              placeholder="비밀번호 확인"
+              autocomplete="new-password"
+              onIonInput={(e) => setPasswordConfirm(e.detail.value ?? '')}
+            />
+          </div>
+        )}
+
+        {error && <p className="login-form__error">{error}</p>}
+
+        <IonButton expand="block" type="submit" disabled={loading} className="login-form__submit">
+          {loading ? <IonSpinner name="crescent" /> : mode === 'signup' ? '회원가입' : '로그인'}
+        </IonButton>
+      </form>
+
+      <div className="login-form__divider">
+        <span>또는</span>
+      </div>
+
+      <KakaoLoginButton
+        label="카카오로 로그인"
+        fullWidth
+        onSuccess={onSuccess}
+        onError={setError}
+      />
+
+      <p className="login-form__hint">
+        {mode === 'login'
+          ? '계정이 없으신가요? 위의 회원가입을 눌러주세요.'
+          : '이미 계정이 있으신가요? 위의 로그인을 눌러주세요.'}
+      </p>
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/src/components/LoginModal.css
+++ b/src/components/LoginModal.css
@@ -1,0 +1,41 @@
+/* PC 로그인 모달. 폼 높이에 맞춰 가운데 카드처럼 띄운다. */
+.login-modal {
+  --width: 400px;
+  --max-width: 92vw;
+  --height: auto;
+  --border-radius: var(--radius-lg, 16px);
+  --box-shadow: 0 12px 40px rgba(25, 31, 40, 0.18);
+  --background: var(--surface, #ffffff);
+}
+
+.login-modal__body {
+  padding: 20px 24px 28px;
+}
+
+.login-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.login-modal__header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--brand-primary, #3182f6);
+}
+
+.login-modal__header ion-button {
+  --color: var(--text-muted, #8b95a1);
+  margin: 0;
+}
+
+.login-modal__lead {
+  margin: 0 0 20px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary, #4e5968);
+}

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { IonModal, IonButton, IonIcon } from '@ionic/react';
+import { closeOutline } from 'ionicons/icons';
+import LoginForm from './LoginForm';
+import './LoginModal.css';
+
+interface LoginModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/** PC 에서 헤더의 로그인 버튼을 누르면 열리는 로그인/회원가입 모달. */
+const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => (
+  <IonModal isOpen={isOpen} onDidDismiss={onClose} className="login-modal">
+    <div className="login-modal__body">
+      <header className="login-modal__header">
+        <h2>네카라쿠배당토야</h2>
+        <IonButton fill="clear" size="small" aria-label="닫기" onClick={onClose}>
+          <IonIcon slot="icon-only" icon={closeOutline} />
+        </IonButton>
+      </header>
+      <p className="login-modal__lead">로그인하면 관심 공고와 알림 설정을 저장할 수 있어요.</p>
+      <LoginForm onSuccess={onClose} />
+    </div>
+  </IonModal>
+);
+
+export default LoginModal;

--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -1,0 +1,21 @@
+/* 모바일 로그인 페이지. 폼 자체 스타일은 LoginForm.css 에 있다. */
+.login-page {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 28px 20px 40px;
+}
+
+.login-page__title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--text-strong, #191f28);
+}
+
+.login-page__lead {
+  margin: 8px 0 24px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-secondary, #4e5968);
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from 'react';
+import { IonPage, IonContent } from '@ionic/react';
+import { useHistory } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import CommonHeader from '../common/CommonHeader';
+import { useAuth } from '../common/AuthContextType';
+import LoginForm from '../components/LoginForm';
+import './Login.css';
+
+/**
+ * 모바일 로그인 화면. PC 는 헤더에서 모달로 열고, 모바일은 이 페이지로 이동한다.
+ * 로그인에 성공하면 이전 화면(없으면 홈)으로 돌아간다.
+ */
+const Login: React.FC = () => {
+  const history = useHistory();
+  const { isLoggedIn } = useAuth();
+
+  // 이미 로그인한 상태로 들어오면(뒤로가기 등) 머무를 이유가 없다.
+  useEffect(() => {
+    if (isLoggedIn) {
+      history.replace('/');
+    }
+  }, [isLoggedIn, history]);
+
+  const handleSuccess = () => {
+    history.replace('/');
+  };
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>로그인</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="네카라쿠배당토야 로그인 및 회원가입" />
+      </Helmet>
+      <CommonHeader />
+      <IonContent>
+        <div className="login-page">
+          <h1 className="login-page__title">로그인</h1>
+          <p className="login-page__lead">로그인하면 관심 공고와 알림 설정을 저장할 수 있어요.</p>
+          <LoginForm onSuccess={handleSuccess} />
+        </div>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
헤더에 카카오 버튼만 있던 것을 **`로그인` 버튼 하나**로 바꾸고, 그 안에서 이메일 로그인·회원가입·카카오 로그인을 모두 고를 수 있게 합니다.

백엔드 PR: kingle1024/nklcbdty-service#201 (`/api/auth/**` 신규) — **먼저 배포되어야 합니다.**

## 화면 분기

| | 동작 |
|---|---|
| PC (>768px) | 헤더 `로그인` → 모달 |
| 모바일 (≤768px) | 헤더 `로그인` → `/login` 페이지 이동 |

두 화면은 같은 `LoginForm` 을 공유합니다. `matchMedia` 를 구독하므로 창 크기를 바꿔도 따라옵니다.

## 구성

- **`common/authApi.ts`** — `/api/auth/{login,signup,email-exists}` 호출. 서버 메시지 추출과 네트워크 오류 문구를 한 곳에서 처리
- **`components/LoginForm.tsx`** — 로그인/회원가입 탭, 클라이언트 검증(이메일 형식·8자 이상·비밀번호 확인), "또는" 구분선 아래 카카오 버튼
- **`components/LoginModal.tsx`** — PC 용 래퍼
- **`pages/Login.tsx`** — 모바일 용. 이미 로그인 상태로 들어오면 홈으로 돌림
- **`common/useIsMobile.ts`** — 768px 미디어쿼리 훅

기존 `KakoLoginButton` 은 `label`/`fullWidth`/`onSuccess`/`onError` 옵션을 받게 확장했고, 토큰 저장 로직은 `AuthContext` 로 넘겨 자체 로그인과 동일한 경로를 타게 했습니다.

> [!NOTE]
> `LoginModal` 을 `ion-header` **안**에 두면 Ionic 이 오버레이를 `<template>` 에 가둬 열리지 않습니다. 헤더 밖에 두어야 합니다 (`CommonHeader` 주석 참고).

## 같이 고친 버그 2건

**1. 새로고침하면 `user` 가 null 이 됐습니다.** `AuthProvider` 가 `isLoggedIn` 은 localStorage 로 복원하면서 `user` 는 복원하지 않았습니다. 카카오/자체 로그인 성공 처리를 `login(auth)` 하나로 합치고, 토큰과 사용자 정보를 함께 저장·복원합니다.

**2. 토큰 재발급 요청 형태가 백엔드와 달랐습니다.** 백엔드 `RefreshRequest` 는 `userVo` 를 받는데 `user` 로 보내고 있어 재발급이 항상 실패했습니다. (백엔드 쪽 Redis 미연결 문제와 겹쳐 있었고, 그건 위 백엔드 PR에서 고쳤습니다)

이 둘 때문에 로그인이 1시간 뒤 끊기고 복구되지 않았습니다.

## 검증

`npx tsc --noEmit` 통과, 프로덕션 빌드 성공. 개발 서버를 띄워 DOM 으로 확인:

- PC 폭: 헤더 `로그인` → 모달 열림 (`is-open=true`), 탭·입력·카카오 버튼 렌더 확인
- 탭 전환: 회원가입 시 닉네임 + 비밀번호 확인 필드 추가, 버튼 문구 변경
- 모바일 폭: 모달이 DOM 에 아예 렌더되지 않고, 버튼 클릭 시 `/login` 이동

> [!NOTE]
> 브라우저 창이 표시되지 않는 헤드리스 환경이라 `requestAnimationFrame` 이 멈춰 Ionic 이 shadow DOM 을 그리지 않았습니다(`ion-button` 등 전부 동일). 그래서 **스크린샷 기준 시각 확인은 못 했고** DOM 구조까지만 검증했습니다. 모달·페이지의 실제 모양은 리뷰 시 한 번 봐주세요.

## 참고

같은 워킹트리에 있던 다른 미커밋 작업(`Dockerfile`, `nginx.conf`, `public/_redirects`, `kvCache.ts`, `App.tsx` 의 주석 변경)은 이 PR에 포함하지 않았습니다. `App.tsx` 는 헝크 단위로 분리해 라우트 추가 2줄만 담았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email-based login and signup with validation and immediate sign-in after registration.
  * Added responsive authentication experiences: desktop users see a login modal, while mobile users use a dedicated `/login` page.
  * Added Kakao login support with configurable button labels and full-width styling.
  * Added persistent authentication, including automatic token refresh and restoration after reopening the app.
  * Added email availability checking and user-friendly authentication error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->