### PR TITLE
✨ Feat: 회사별 "채용 페이지로 가기" 버튼

### DIFF
--- a/src/components/ListContainer.css
+++ b/src/components/ListContainer.css
@@ -195,6 +195,31 @@ li {
   border-radius: var(--radius-lg);
 }
 
+.no-data-career-link {
+  margin-top: 12px;
+  font-size: 14px;
+}
+
+/* 선택한 회사의 채용 페이지 바로가기 */
+.career-page-section {
+  display: flex;
+  margin-top: -8px;
+  margin-bottom: 16px;
+}
+
+.career-page-btn {
+  margin: 0;
+  height: 32px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: -0.01em;
+  --border-radius: var(--radius-pill);
+  --border-width: 1px;
+  --padding-start: 14px;
+  --padding-end: 14px;
+}
+
 .badge-new {
   display: inline-block;
   margin-left: 6px;

--- a/src/components/ListContainer.tsx
+++ b/src/components/ListContainer.tsx
@@ -26,6 +26,13 @@ interface ListContainerProps {
   filters: Filters;
 }
 
+// /api/company/list — 회사 코드별 채용 페이지 주소 ("채용 페이지로 가기" 버튼용)
+interface CompanyInfo {
+  companyCd: string;
+  companyNm: string;
+  careerPageUrl: string;
+}
+
 const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
   const [products, setProducts] = useState<Job_mst[]>([]);
   const [company, setCompany] = useState<string>('NAVER');
@@ -34,6 +41,8 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
   // 삭제요청(PENDING)된 공고 id 집합 — 버튼 상태 표시용
   const [requestedDeleteIds, setRequestedDeleteIds] = useState<Set<number>>(new Set());
   const [requestingDeleteId, setRequestingDeleteId] = useState<number | null>(null);
+  // 회사코드 -> 채용 페이지 주소
+  const [careerPageUrls, setCareerPageUrls] = useState<{ [companyCd: string]: string }>({});
 
   useEffect(() => {
     const fetchData = async () => {
@@ -74,6 +83,26 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
       }
     };
     fetchPendingDeleteIds();
+  }, []);
+
+  // 회사별 채용 페이지 주소를 받아온다. 실패하면 버튼만 안 보이고 목록은 그대로 동작한다.
+  useEffect(() => {
+    const fetchCareerPages = async () => {
+      try {
+        const response = await axios.get<CompanyInfo[]>(`${API_URL}/api/company/list`);
+        if (Array.isArray(response.data)) {
+          setCareerPageUrls(
+            response.data.reduce((acc: { [companyCd: string]: string }, item) => {
+              acc[item.companyCd] = item.careerPageUrl;
+              return acc;
+            }, {})
+          );
+        }
+      } catch (error) {
+        console.error('회사 채용 페이지 목록 조회 실패:', error);
+      }
+    };
+    fetchCareerPages();
   }, []);
 
   const handleDeleteRequest = async (jobId: number | null) => {
@@ -256,6 +285,22 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
           ))}
         </div>
 
+        {/* 선택한 회사의 채용 페이지로 바로 이동. 크롤링에 안 잡힌 공고는 여기서 확인할 수 있다. */}
+        {careerPageUrls[company] && (
+          <div className="career-page-section">
+            <IonButton
+              size="small"
+              fill="outline"
+              className="career-page-btn"
+              href={careerPageUrls[company]}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {companies[company]} 채용 페이지로 가기
+            </IonButton>
+          </div>
+        )}
+
         <div className="card-container">
           {sortedProducts.length > 0 ? (
             sortedProducts.map((item: Job_mst) => {
@@ -324,6 +369,13 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
           ) : (
             <div className="no-data-message">
               데이터가 없습니다.
+              {careerPageUrls[company] && (
+                <div className="no-data-career-link">
+                  <a href={careerPageUrls[company]} target="_blank" rel="noopener noreferrer">
+                    {companies[company]} 채용 페이지에서 직접 확인하기
+                  </a>
+                </div>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
회사 탭 아래에 선택한 회사의 채용 페이지 바로가기 버튼을 추가한다.

당근마켓·야놀자처럼 채용 사이트가 이관돼 크롤링이 비거나, 회사가 실제로 공고를 안 올린 기간에도 사용자가 회사 채용 페이지로는 갈 수 있게 하는 게 목적이다. 그래서 공고가 0건일 때 뜨는 "데이터가 없습니다" 안에도 같은 링크를 넣었다.

- 주소는 백엔드 `GET /api/company/list` 에서 받는다 (`{companyCd, companyNm, careerPageUrl}`). 프론트에 하드코딩하면 회사 채용 사이트가 옮겨갈 때마다 같이 썩는다
- 조회 실패 시 버튼만 안 보이고 목록은 그대로 동작한다
- `전체(ALL)` 탭에서는 버튼이 안 보인다

`tsc --noEmit` 통과.

백엔드: kingle1024/nklcbdty-service#203 (머지됨). 그쪽이 배포되기 전까지는 `/api/company/list` 가 없어 버튼이 안 보이는데, 위 실패 처리 때문에 화면은 지금과 동일하게 동작한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added links to companies’ external career pages when available.
  * Career-page links are shown for selected companies, including when no matching job listings exist.
* **Style**
  * Added layout and visual styling for career-page shortcuts, buttons, and no-data links.
* **Bug Fixes**
  * Career-page lookup failures no longer interrupt job-list loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->