### PR TITLE
✨ Feat: 채용 캘린더 화면 — 그 달 마감 공고를 달력으로

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import '@ionic/react/css/display.css';
 /* Theme variables */
 import './theme.css';
 import Mypage from './pages/Mypage';
+import Calendar from './pages/Calendar';
 import Login from './pages/Login';
 import Email from './pages/EmailInquiry';
 import AdminHome from './pages/AdminHome';
@@ -51,6 +52,7 @@ const App: React.FC = () => {
           <IonReactRouter>
             <IonRouterOutlet>
               <Route path='/' component={Home} exact={true} />
+              <Route path='/calendar' component={Calendar} exact={true} />
               <Route path='/mypage' component={Mypage} exact={true} />
               <Route path='/login' component={Login} exact={true} />
               <Route path='/email' component={Email} exact={true} />

--- a/src/common/CommonHeader.tsx
+++ b/src/common/CommonHeader.tsx
@@ -30,6 +30,7 @@ const CommonHeader: React.FC = () => {
       <IonToolbar>
         <IonTitle onClick={handleTitleClick} style={{ cursor: 'pointer' }}>네카라쿠배당토야</IonTitle>
         <IonButtons slot='end'>
+          <IonButton routerLink="/calendar">채용 캘린더</IonButton>
           <IonButton routerLink="/email">문의 및 건의사항</IonButton>
           {isLoggedIn ? (
             <>

--- a/src/common/companies.ts
+++ b/src/common/companies.ts
@@ -1,0 +1,29 @@
+/**
+ * 회사 코드(job_mst.company_cd) → 표시 이름 / 브랜드 색.
+ *
+ * 목록(ListContainer)과 캘린더(Calendar)가 같은 회사 탭·같은 색을 쓰도록 한곳에 모았다.
+ * 'ALL' 은 화면의 "전체" 탭 전용 키로, 서버에도 같은 값으로 넘긴다.
+ */
+export const COMPANY_NAMES: { [key: string]: string } = {
+  ALL: '전체',
+  NAVER: '네이버',
+  KAKAO: '카카오',
+  LINE: '라인',
+  COUPANG: '쿠팡',
+  BAEMIN: '배달의민족',
+  DAANGN: '당근마켓',
+  TOSS: '토스',
+  YANOLJA: '야놀자',
+};
+
+export const COMPANY_COLORS: { [key: string]: string } = {
+  NAVER: '#1EC800',
+  KAKAO: '#FFEB00',
+  LINE: '#00B700',
+  COUPANG: '',
+  BAEMIN: '#48D1CC',
+  DAANGN: '#EB8717',
+  TOSS: '#3182F7',
+  YANOLJA: '#F5A3B8',
+  ALL: 'transparent',
+};

--- a/src/components/ListContainer.tsx
+++ b/src/components/ListContainer.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import API_URL from "../config";
 import { cachedGet } from '../common/kvCache';
+import { COMPANY_COLORS, COMPANY_NAMES } from '../common/companies';
 import './ListContainer.css';
 import { IonButton, IonSearchbar } from '@ionic/react';
 import { Filters } from '../pages/Home';
@@ -131,29 +132,9 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
     setCompany(selectedCompany);
   };
 
-  const companies: { [key: string]: string } = {
-    ALL: '전체',
-    NAVER: '네이버',
-    KAKAO: '카카오',
-    LINE: '라인',
-    COUPANG: '쿠팡',
-    BAEMIN: '배달의민족',
-    DAANGN: '당근마켓',
-    TOSS: '토스',
-    YANOLJA: '야놀자',
-  };
-
-  const companyColors: { [key: string]: string } = {
-    NAVER: '#1EC800',
-    KAKAO: '#FFEB00',
-    LINE: '#00B700',
-    COUPANG: '',
-    BAEMIN: '#48D1CC',
-    DAANGN: '#EB8717',
-    TOSS: '#3182F7',
-    YANOLJA: '#F5A3B8',
-    ALL: 'transparent',
-  };
+  // 회사 이름·색은 캘린더 화면과 공유한다 (common/companies.ts)
+  const companies = COMPANY_NAMES;
+  const companyColors = COMPANY_COLORS;
 
   const filteredProducts = products.filter((item) => {
     // 1. 고용 형태 필터링

--- a/src/pages/Calendar.css
+++ b/src/pages/Calendar.css
@@ -244,6 +244,10 @@
   text-align: center;
 }
 
+.calendar-cell__count--closed {
+  background: var(--text-disabled);
+}
+
 /* ---------- 선택한 날짜의 공고 목록 ---------- */
 .calendar-detail {
   margin-top: 20px;
@@ -263,6 +267,11 @@
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-card);
   margin-bottom: 10px;
+}
+
+/* 이미 마감된 공고 — "마감" 배지와 함께 카드 자체도 흐리게 */
+.calendar-job--closed {
+  opacity: 0.6;
 }
 
 .calendar-job__bar {

--- a/src/pages/Calendar.css
+++ b/src/pages/Calendar.css
@@ -1,0 +1,334 @@
+/* 채용 캘린더 — 마감일 기준 월별 달력 */
+
+.calendar-page {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 16px 12px 32px;
+}
+
+/* ---------- 상단 월 이동 ---------- */
+.calendar-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.calendar-title {
+  font-size: 20px;
+  font-weight: 800;
+  margin: 0;
+  min-width: 130px;
+  text-align: center;
+}
+
+.calendar-toolbar ion-button.calendar-nav-btn {
+  --color: var(--text-secondary);
+  --padding-start: 8px;
+  --padding-end: 8px;
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.calendar-toolbar ion-button.calendar-today-btn {
+  margin-left: auto;
+  height: 32px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: none;
+  --border-radius: var(--radius-pill);
+  --border-width: 1px;
+}
+
+/* ---------- 회사 필터 (목록 화면과 같은 알약형 칩) ---------- */
+.calendar-company-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.calendar-company-filter ion-button {
+  flex: 0 0 auto;
+  margin: 0;
+  height: 34px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: -0.01em;
+  --border-radius: var(--radius-pill);
+  --padding-start: 14px;
+  --padding-end: 14px;
+  --box-shadow: none;
+}
+
+/* ---------- 요약 / 상태 ---------- */
+.calendar-summary {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0 0 12px;
+}
+
+.calendar-summary strong {
+  color: var(--brand-primary);
+}
+
+.calendar-summary__note {
+  display: block;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.calendar-status {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 120px;
+  font-size: 14px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* ---------- 달력 그리드 ---------- */
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 12px;
+}
+
+.calendar-weekday {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-align: center;
+  padding-bottom: 4px;
+}
+
+.calendar-weekday--saturday {
+  color: var(--brand-primary);
+}
+
+.calendar-weekday--sunday {
+  color: var(--danger);
+}
+
+/* 셀은 버튼 — 클릭으로 그날 공고를 펼친다 */
+.calendar-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  min-height: 96px;
+  padding: 6px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.calendar-cell--blank {
+  background: transparent;
+  cursor: default;
+}
+
+.calendar-cell--empty {
+  cursor: default;
+}
+
+.calendar-cell--has-jobs:hover {
+  border-color: var(--brand-primary);
+}
+
+.calendar-cell--selected {
+  border-color: var(--brand-primary);
+  background: var(--brand-primary-tint);
+}
+
+.calendar-cell--today .calendar-cell__day {
+  background: var(--brand-primary);
+  color: #fff;
+  border-radius: var(--radius-pill);
+  padding: 0 6px;
+}
+
+.calendar-cell__day {
+  align-self: flex-start;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-strong);
+  line-height: 18px;
+}
+
+.calendar-cell--saturday .calendar-cell__day {
+  color: var(--brand-primary);
+}
+
+.calendar-cell--sunday .calendar-cell__day {
+  color: var(--danger);
+}
+
+.calendar-cell--today .calendar-cell__day,
+.calendar-cell--today.calendar-cell--saturday .calendar-cell__day,
+.calendar-cell--today.calendar-cell--sunday .calendar-cell__day {
+  color: #fff;
+}
+
+/* ---------- 셀 안의 공고 칩 (PC) ---------- */
+.calendar-cell__chips {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.calendar-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  padding: 2px 4px;
+  border-radius: 4px;
+  background: var(--surface);
+  font-size: 11px;
+  color: var(--text-body);
+}
+
+.calendar-chip--closed {
+  opacity: 0.45;
+  text-decoration: line-through;
+}
+
+.calendar-chip__dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+}
+
+.calendar-chip__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.calendar-chip__more {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding-left: 4px;
+}
+
+/* ---------- 셀 안의 건수 배지 (모바일) ---------- */
+.calendar-cell__count {
+  align-self: center;
+  margin-top: auto;
+  margin-bottom: auto;
+  min-width: 22px;
+  padding: 2px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--brand-primary);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+/* ---------- 선택한 날짜의 공고 목록 ---------- */
+.calendar-detail {
+  margin-top: 20px;
+}
+
+.calendar-detail__title {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 10px;
+}
+
+.calendar-job {
+  display: flex;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  margin-bottom: 10px;
+}
+
+.calendar-job__bar {
+  flex: 0 0 8px;
+}
+
+.calendar-job__body {
+  padding: 12px 14px;
+  min-width: 0;
+}
+
+.calendar-job__title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+
+.calendar-badge-closed {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--danger);
+  background: var(--danger-tint);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+}
+
+.calendar-job__meta {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0 0 6px;
+}
+
+.calendar-job__body a {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--brand-primary);
+  text-decoration: none;
+}
+
+.calendar-job__body a:hover {
+  text-decoration: underline;
+}
+
+/* ---------- 모바일 ---------- */
+@media (max-width: 768px) {
+  .calendar-page {
+    padding: 12px 8px 24px;
+  }
+
+  .calendar-grid {
+    gap: 4px;
+    padding: 8px;
+    border-radius: var(--radius-md);
+  }
+
+  .calendar-cell {
+    min-height: 52px;
+    padding: 4px;
+  }
+
+  .calendar-title {
+    font-size: 18px;
+    min-width: 110px;
+  }
+}

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,0 +1,322 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import { IonButton, IonContent, IonFooter, IonPage, IonSpinner, IonText, IonToolbar } from '@ionic/react';
+import { Helmet } from 'react-helmet';
+import API_URL from '../config';
+import CommonHeader from '../common/CommonHeader';
+import useIsMobile from '../common/useIsMobile';
+import { COMPANY_COLORS, COMPANY_NAMES } from '../common/companies';
+import './Calendar.css';
+
+interface CalendarJob {
+  id: number | null;
+  annoId: string;
+  companyCd: string;
+  companyNm: string;
+  annoSubject: string;
+  subJobCdNm: string | null;
+  empTypeCdNm: string | null;
+  workplace: string | null;
+  jobDetailLink: string;
+  endDate: string;
+  endTime: string | null;
+  closed: boolean;
+}
+
+interface CalendarDay {
+  date: string;
+  dayOfWeek: number;
+  count: number;
+  jobs: CalendarJob[];
+}
+
+interface CalendarMonth {
+  year: number;
+  month: number;
+  firstDayOfWeek: number;
+  lengthOfMonth: number;
+  totalCount: number;
+  days: CalendarDay[];
+}
+
+interface TargetMonth {
+  year: number;
+  month: number;
+}
+
+/** 달력은 월요일 시작. 서버의 dayOfWeek(1=월 ~ 7=일)와 인덱스를 맞춘다. */
+const WEEKDAYS = ['월', '화', '수', '목', '금', '토', '일'];
+
+/** PC 셀에 미리 보여줄 공고 수. 넘치면 "+N건" 으로 접는다. */
+const MAX_CHIPS_PER_CELL = 3;
+
+const pad = (value: number) => String(value).padStart(2, '0');
+
+const toDateKey = (year: number, month: number, day: number) => `${year}-${pad(month)}-${pad(day)}`;
+
+const thisMonth = (): TargetMonth => {
+  const now = new Date();
+  return { year: now.getFullYear(), month: now.getMonth() + 1 };
+};
+
+const todayKey = () => {
+  const now = new Date();
+  return toDateKey(now.getFullYear(), now.getMonth() + 1, now.getDate());
+};
+
+const shiftMonth = ({ year, month }: TargetMonth, delta: number): TargetMonth => {
+  // Date 가 연 넘어감(12월 → 1월)을 알아서 처리한다.
+  const shifted = new Date(year, month - 1 + delta, 1);
+  return { year: shifted.getFullYear(), month: shifted.getMonth() + 1 };
+};
+
+/**
+ * 처음 열었을 때 펼쳐 둘 날짜.
+ * 아직 지원할 수 있는 가장 가까운 마감일을 고르고, 그런 날이 없으면(지난 달 조회) 그 달 첫 마감일.
+ * ISO 문자열(yyyy-MM-dd)은 사전순 비교가 날짜순 비교와 같다.
+ */
+const pickDefaultDate = (month: CalendarMonth): string | null => {
+  if (month.days.length === 0) {
+    return null;
+  }
+  const today = todayKey();
+  const upcoming = month.days.find((day) => day.date >= today);
+  return (upcoming ?? month.days[0]).date;
+};
+
+/** 공고 클릭 로그. 목록 화면과 같은 API 를 쓴다. 실패해도 이동은 막지 않는다. */
+const logJobClick = (job: CalendarJob) => {
+  const url = `${API_URL}/api/log/job_history?anno_id=${job.annoId}&anno_subject=${encodeURIComponent(job.annoSubject)}`;
+  axios.get(url).catch(() => undefined);
+};
+
+const Calendar: React.FC = () => {
+  const isMobile = useIsMobile();
+  const [target, setTarget] = useState<TargetMonth>(thisMonth);
+  const [company, setCompany] = useState<string>('ALL');
+  const [data, setData] = useState<CalendarMonth | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [hasError, setHasError] = useState<boolean>(false);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  useEffect(() => {
+    // 달/회사를 빠르게 바꾸면 먼저 보낸 요청이 늦게 도착해 화면을 덮을 수 있어 취소 플래그를 둔다.
+    let cancelled = false;
+
+    const fetchCalendar = async () => {
+      setLoading(true);
+      setHasError(false);
+      try {
+        // 마감 여부(closed)는 시시각각 바뀌므로 KV 캐시를 타지 않고 원본 API 에서 받는다.
+        const response = await axios.get<CalendarMonth>(`${API_URL}/api/calendar/deadlines`, {
+          params: { year: target.year, month: target.month, company },
+        });
+        if (cancelled) return;
+        setData(response.data);
+        setSelectedDate(pickDefaultDate(response.data));
+      } catch (error) {
+        if (cancelled) return;
+        console.error('캘린더 조회 실패:', error);
+        setData(null);
+        setHasError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchCalendar();
+    return () => {
+      cancelled = true;
+    };
+  }, [target, company]);
+
+  const daysByDate = useMemo(() => {
+    const map = new Map<string, CalendarDay>();
+    data?.days.forEach((day) => map.set(day.date, day));
+    return map;
+  }, [data]);
+
+  const selectedDay = selectedDate ? daysByDate.get(selectedDate) : undefined;
+  const today = todayKey();
+
+  const renderCells = (month: CalendarMonth) => {
+    // 1일이 월요일이 아니면 그만큼 앞을 비운다.
+    const blanks = Array.from({ length: month.firstDayOfWeek - 1 }, (_, index) => (
+      <div className="calendar-cell calendar-cell--blank" key={`blank-${index}`} />
+    ));
+
+    const cells = Array.from({ length: month.lengthOfMonth }, (_, index) => {
+      const dayNumber = index + 1;
+      const dateKey = toDateKey(month.year, month.month, dayNumber);
+      const day = daysByDate.get(dateKey);
+      const dayOfWeek = ((month.firstDayOfWeek - 1 + index) % 7) + 1;
+
+      const classNames = [
+        'calendar-cell',
+        day ? 'calendar-cell--has-jobs' : 'calendar-cell--empty',
+        dateKey === today ? 'calendar-cell--today' : '',
+        dateKey === selectedDate ? 'calendar-cell--selected' : '',
+        dayOfWeek === 6 ? 'calendar-cell--saturday' : '',
+        dayOfWeek === 7 ? 'calendar-cell--sunday' : '',
+      ].filter(Boolean).join(' ');
+
+      return (
+        <button
+          type="button"
+          className={classNames}
+          key={dateKey}
+          disabled={!day}
+          onClick={() => setSelectedDate(dateKey)}
+          aria-label={day ? `${month.month}월 ${dayNumber}일 마감 ${day.count}건` : `${month.month}월 ${dayNumber}일`}
+        >
+          <span className="calendar-cell__day">{dayNumber}</span>
+          {day && (isMobile ? (
+            <span className="calendar-cell__count">{day.count}</span>
+          ) : (
+            <span className="calendar-cell__chips">
+              {day.jobs.slice(0, MAX_CHIPS_PER_CELL).map((job) => (
+                <span
+                  className={`calendar-chip${job.closed ? ' calendar-chip--closed' : ''}`}
+                  key={job.id ?? `${job.companyCd}-${job.annoId}`}
+                >
+                  <i className="calendar-chip__dot" style={{ backgroundColor: COMPANY_COLORS[job.companyCd] || 'var(--text-muted)' }} />
+                  <span className="calendar-chip__text">{job.companyNm} {job.annoSubject}</span>
+                </span>
+              ))}
+              {day.count > MAX_CHIPS_PER_CELL && (
+                <span className="calendar-chip__more">+{day.count - MAX_CHIPS_PER_CELL}건</span>
+              )}
+            </span>
+          ))}
+        </button>
+      );
+    });
+
+    return [...blanks, ...cells];
+  };
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>채용 캘린더 | 네카라쿠배당토야</title>
+        <meta name="description" content="네카라쿠배당토야 채용 공고 마감일을 달력으로 한눈에. 네이버, 카카오, 라인, 쿠팡, 배달의민족, 당근마켓, 토스, 야놀자 공고 마감일 확인." />
+        <meta property="og:title" content="채용 캘린더 | 네카라쿠배당토야" />
+        <meta property="og:description" content="이번 달 마감되는 채용 공고를 달력으로 확인하세요." />
+      </Helmet>
+      <CommonHeader />
+      <IonContent fullscreen>
+        <div className="calendar-page">
+          <div className="calendar-toolbar">
+            {/* 연속으로 빠르게 눌러도 한 달만 움직이지 않도록 이전 상태에서 계산한다 */}
+            <IonButton fill="clear" className="calendar-nav-btn" onClick={() => setTarget((prev) => shiftMonth(prev, -1))} aria-label="이전 달">
+              &lsaquo;
+            </IonButton>
+            <h1 className="calendar-title">{target.year}년 {target.month}월</h1>
+            <IonButton fill="clear" className="calendar-nav-btn" onClick={() => setTarget((prev) => shiftMonth(prev, 1))} aria-label="다음 달">
+              &rsaquo;
+            </IonButton>
+            <IonButton size="small" fill="outline" className="calendar-today-btn" onClick={() => setTarget(thisMonth())}>
+              이번 달
+            </IonButton>
+          </div>
+
+          <div className="calendar-company-filter">
+            {Object.keys(COMPANY_NAMES).map((companyCd) => (
+              <IonButton
+                key={companyCd}
+                onClick={() => setCompany(companyCd)}
+                color={company === companyCd ? 'primary' : 'medium'}
+              >
+                {COMPANY_NAMES[companyCd]}
+              </IonButton>
+            ))}
+          </div>
+
+          {loading && (
+            <div className="calendar-status">
+              <IonSpinner name="crescent" />
+            </div>
+          )}
+
+          {!loading && hasError && (
+            <div className="calendar-status">
+              캘린더를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+            </div>
+          )}
+
+          {!loading && !hasError && data && (
+            <>
+              <p className="calendar-summary">
+                {data.month}월에 마감되는 공고 <strong>{data.totalCount}건</strong>
+                <span className="calendar-summary__note">상시채용(영입종료시) 공고는 마감일이 없어 캘린더에 표시되지 않습니다.</span>
+              </p>
+
+              <div className="calendar-grid">
+                {WEEKDAYS.map((label, index) => (
+                  <div
+                    className={`calendar-weekday${index === 5 ? ' calendar-weekday--saturday' : ''}${index === 6 ? ' calendar-weekday--sunday' : ''}`}
+                    key={label}
+                  >
+                    {label}
+                  </div>
+                ))}
+                {renderCells(data)}
+              </div>
+
+              {selectedDay ? (
+                <section className="calendar-detail">
+                  <h2 className="calendar-detail__title">
+                    {selectedDay.date.replace(/^\d{4}-0?(\d+)-0?(\d+)$/, '$1월 $2일')} ({WEEKDAYS[selectedDay.dayOfWeek - 1]}) 마감 {selectedDay.count}건
+                  </h2>
+                  {selectedDay.jobs.map((job) => (
+                    <div className="calendar-job" key={job.id ?? `${job.companyCd}-${job.annoId}`}>
+                      <span
+                        className="calendar-job__bar"
+                        style={{ backgroundColor: COMPANY_COLORS[job.companyCd] || 'var(--border)' }}
+                      />
+                      <div className="calendar-job__body">
+                        <h3 className="calendar-job__title">
+                          {job.annoSubject}
+                          {job.closed && <span className="calendar-badge-closed">마감</span>}
+                        </h3>
+                        <p className="calendar-job__meta">
+                          {job.companyNm}
+                          {job.subJobCdNm ? ` | ${job.subJobCdNm}` : ''}
+                          {job.endTime ? ` | ${job.endTime} 마감` : ''}
+                          {job.workplace ? ` | ${job.workplace}` : ''}
+                        </p>
+                        <a
+                          href={job.jobDetailLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => logJobClick(job)}
+                        >
+                          자세히 보기
+                        </a>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              ) : (
+                <div className="calendar-status">
+                  {data.totalCount === 0
+                    ? '이 달에 마감되는 공고가 없습니다.'
+                    : '날짜를 선택하면 그날 마감되는 공고를 볼 수 있습니다.'}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </IonContent>
+      <IonFooter>
+        <IonToolbar>
+          <IonText className="footer-text">
+            &copy; 2025 네카라쿠배당토야.
+          </IonText>
+        </IonToolbar>
+      </IonFooter>
+    </IonPage>
+  );
+};
+
+export default Calendar;

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -72,16 +72,15 @@ const shiftMonth = ({ year, month }: TargetMonth, delta: number): TargetMonth =>
 
 /**
  * 처음 열었을 때 펼쳐 둘 날짜.
- * 아직 지원할 수 있는 가장 가까운 마감일을 고르고, 그런 날이 없으면(지난 달 조회) 그 달 첫 마감일.
- * ISO 문자열(yyyy-MM-dd)은 사전순 비교가 날짜순 비교와 같다.
+ * 아직 지원할 수 있는 공고가 남은 가장 이른 날을 고른다. 오늘이라도 그날 마감이 이미
+ * 다 지났으면 건너뛴다. 그런 날이 없으면(지난 달 조회) 그 달 첫 마감일.
  */
 const pickDefaultDate = (month: CalendarMonth): string | null => {
   if (month.days.length === 0) {
     return null;
   }
-  const today = todayKey();
-  const upcoming = month.days.find((day) => day.date >= today);
-  return (upcoming ?? month.days[0]).date;
+  const open = month.days.find((day) => day.jobs.some((job) => !job.closed));
+  return (open ?? month.days[0]).date;
 };
 
 /** 공고 클릭 로그. 목록 화면과 같은 API 를 쓴다. 실패해도 이동은 막지 않는다. */
@@ -171,7 +170,10 @@ const Calendar: React.FC = () => {
         >
           <span className="calendar-cell__day">{dayNumber}</span>
           {day && (isMobile ? (
-            <span className="calendar-cell__count">{day.count}</span>
+            // 그날 공고가 전부 마감이면 배지도 흐리게 — 지난 달을 봐도 진행 중처럼 보이지 않게
+            <span className={`calendar-cell__count${day.jobs.every((job) => job.closed) ? ' calendar-cell__count--closed' : ''}`}>
+              {day.count}
+            </span>
           ) : (
             <span className="calendar-cell__chips">
               {day.jobs.slice(0, MAX_CHIPS_PER_CELL).map((job) => (
@@ -269,7 +271,10 @@ const Calendar: React.FC = () => {
                     {selectedDay.date.replace(/^\d{4}-0?(\d+)-0?(\d+)$/, '$1월 $2일')} ({WEEKDAYS[selectedDay.dayOfWeek - 1]}) 마감 {selectedDay.count}건
                   </h2>
                   {selectedDay.jobs.map((job) => (
-                    <div className="calendar-job" key={job.id ?? `${job.companyCd}-${job.annoId}`}>
+                    <div
+                      className={`calendar-job${job.closed ? ' calendar-job--closed' : ''}`}
+                      key={job.id ?? `${job.companyCd}-${job.annoId}`}
+                    >
                       <span
                         className="calendar-job__bar"
                         style={{ backgroundColor: COMPANY_COLORS[job.companyCd] || 'var(--border)' }}


### PR DESCRIPTION
## 무엇

헤더의 **채용 캘린더**(`/calendar`)에서 그 달에 마감되는 공고를 날짜별로 본다.
백엔드 PR: kingle1024/nklcbdty-service#206 (`GET /api/calendar/deadlines`) — **백엔드 배포 후에 배포해야 한다.**

## 화면

- 월 이동(`‹ ›` · "이번 달")과 회사 필터(목록 화면과 같은 칩)
- 월요일 시작 7열 그리드. 서버가 주는 `firstDayOfWeek`/`lengthOfMonth` 로 칸을 배치하고 오늘·주말을 구분
- PC 는 칸 안에 공고 칩 최대 3개 + `+N건`, 모바일은 건수 배지 → 날짜를 누르면 아래에 그날 마감 공고 전체(회사 · 직무 · 마감시각 · 근무지 · 자세히 보기)
- 이미 지난 마감은 흐리게 + `마감` 배지. 처음 열면 아직 지원할 수 있는 가장 가까운 마감일이 펼쳐진다
- 공고가 없는 달은 "이 달에 마감되는 공고가 없습니다."
- 상시채용(`영입종료시`)은 마감일이 없어 캘린더에 안 나온다는 안내를 상단에 표기

## 구현 메모

- 마감 여부(`closed`)가 시시각각 바뀌므로 목록과 달리 KV 캐시(`cachedGet`)를 타지 않고 원본 API 를 직접 호출한다.
- 공고 클릭 로그는 목록과 같은 `/api/log/job_history` 를 쓴다.
- 회사 이름·브랜드색이 목록/캘린더 양쪽에 필요해 `common/companies.ts` 로 뽑고, `ListContainer` 의 하드코딩 맵을 교체했다(동작 변화 없음).
- 스타일은 `theme.css` 토큰만 사용.

## 확인

`tsc --noEmit` · `eslint` 통과(새 파일 경고 0). 로컬에서 API 를 스텁으로 띄우고 dev 서버로 확인: 월 이동, 회사 필터, 날짜 선택(하루 5건 케이스 포함), 지난 달 `마감` 표시, 공고 없는 달, 모바일 375px 배지 렌더, 헤더 링크 이동, 홈 화면 회사 탭 이상 없음. 새 코드에서 콘솔 에러 없음.

`/calendar` 딥링크는 기존 SPA 폴백(`public/_redirects`, `nginx.conf` 의 `try_files`)으로 그대로 동작한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recruitment calendar accessible from the main header.
  * Browse hiring deadlines by month and company.
  * Select dates to view detailed job information.
  * Added responsive calendar layouts for desktop and mobile.
  * Added visual indicators for closed positions and company branding.

* **Improvements**
  * Standardized company names and colors across job listings and calendar views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->