### PR TITLE
✨ Feat: 캘린더 2단 배치(PC) · 팝업(모바일) + 목록 로딩 표시

### DIFF
--- a/src/components/ListContainer.css
+++ b/src/components/ListContainer.css
@@ -185,6 +185,22 @@ li {
   max-width: 100%;
 }
 
+/* 응답 오기 전. "데이터가 없습니다" 를 먼저 보여주면 공고가 없는 줄 안다. */
+.list-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 48px 20px;
+  color: var(--text-muted);
+}
+
+.list-loading p {
+  margin: 0;
+  font-size: 14px;
+}
+
 .no-data-message {
   text-align: center;
   font-size: 15px;

--- a/src/components/ListContainer.tsx
+++ b/src/components/ListContainer.tsx
@@ -4,7 +4,7 @@ import API_URL from "../config";
 import { cachedGet } from '../common/kvCache';
 import { COMPANY_COLORS, COMPANY_NAMES } from '../common/companies';
 import './ListContainer.css';
-import { IonButton, IonSearchbar } from '@ionic/react';
+import { IonButton, IonSearchbar, IonSpinner } from '@ionic/react';
 import { Filters } from '../pages/Home';
 
 interface Job_mst {
@@ -44,14 +44,19 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
   const [requestingDeleteId, setRequestingDeleteId] = useState<number | null>(null);
   // 회사코드 -> 채용 페이지 주소
   const [careerPageUrls, setCareerPageUrls] = useState<{ [companyCd: string]: string }>({});
+  // 응답 전에는 "데이터가 없습니다"·채용 페이지 안내 대신 로딩을 보여준다.
+  // 잠든 서버가 깨어나는 몇 초 동안 공고가 없는 것처럼 보이던 문제.
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
     const fetchData = async () => {
       if (cache[company]) {
         setProducts(cache[company]);
+        setIsLoading(false);
         return;
       }
 
+      setIsLoading(true);
       try {
         const data = await cachedGet<Job_mst[]>(`nklcb:list:${company}`, `${API_URL}/api/list`, { company });
 
@@ -66,6 +71,8 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
         }
       } catch (error) {
         console.error('Error fetching data:', error);
+      } finally {
+        setIsLoading(false);
       }
     };
     fetchData();
@@ -266,8 +273,9 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
           ))}
         </div>
 
-        {/* 선택한 회사의 채용 페이지로 바로 이동. 크롤링에 안 잡힌 공고는 여기서 확인할 수 있다. */}
-        {careerPageUrls[company] && (
+        {/* 선택한 회사의 채용 페이지로 바로 이동. 크롤링에 안 잡힌 공고는 여기서 확인할 수 있다.
+            응답 전에는 감춘다 — 공고가 없어서 안내하는 것처럼 보이기 때문. */}
+        {!isLoading && careerPageUrls[company] && (
           <div className="career-page-section">
             <IonButton
               size="small"
@@ -283,7 +291,12 @@ const ListContainer: React.FC<ListContainerProps> = ({ filters }) => {
         )}
 
         <div className="card-container">
-          {sortedProducts.length > 0 ? (
+          {isLoading ? (
+            <div className="list-loading">
+              <IonSpinner name="crescent" />
+              <p>공고를 불러오는 중입니다…</p>
+            </div>
+          ) : sortedProducts.length > 0 ? (
             sortedProducts.map((item: Job_mst) => {
               const companyKey = Object.keys(companyColors).find(key => 
                 item.companyCd && item.companyCd.toUpperCase().includes(key.toUpperCase())

--- a/src/pages/Calendar.css
+++ b/src/pages/Calendar.css
@@ -1,9 +1,30 @@
 /* 채용 캘린더 — 마감일 기준 월별 달력 */
 
 .calendar-page {
-  max-width: 1000px;
+  max-width: 1180px;
   margin: 0 auto;
   padding: 16px 12px 32px;
+}
+
+/* PC 는 왼쪽 달력 · 오른쪽 공고 2단. 공고 목록이 달력 아래에 있으면 있는 줄도 모른다. */
+.calendar-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 16px;
+  align-items: start;
+}
+
+@media (max-width: 1024px) {
+  .calendar-layout {
+    grid-template-columns: minmax(0, 1fr) 300px;
+  }
+}
+
+/* 모바일은 2단이 안 들어가 달력만 두고, 공고는 팝업으로 띄운다. */
+@media (max-width: 768px) {
+  .calendar-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 /* ---------- 상단 월 이동 ---------- */
@@ -248,15 +269,38 @@
   background: var(--text-disabled);
 }
 
-/* ---------- 선택한 날짜의 공고 목록 ---------- */
+/* ---------- 선택한 날짜의 공고 목록 (PC: 오른쪽 패널 / 모바일: 팝업 안) ---------- */
 .calendar-detail {
-  margin-top: 20px;
+  /* 달력이 길어도 공고가 늘 눈에 보이게 따라다닌다. */
+  position: sticky;
+  top: 12px;
+  max-height: calc(100vh - 140px);
+  overflow-y: auto;
+  padding: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
 }
 
 .calendar-detail__title {
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 700;
   margin: 0 0 10px;
+}
+
+.calendar-detail__placeholder {
+  margin: 0;
+  padding: 24px 8px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* 패널 안에서는 카드 그림자를 빼 겹쳐 보이지 않게 한다. */
+.calendar-detail .calendar-job {
+  box-shadow: none;
 }
 
 .calendar-job {
@@ -317,6 +361,37 @@
 
 .calendar-job__body a:hover {
   text-decoration: underline;
+}
+
+/* ---------- 모바일 팝업 (바텀 시트) ---------- */
+.calendar-modal {
+  --border-radius: var(--radius-lg, 16px) var(--radius-lg, 16px) 0 0;
+  --background: var(--surface, #ffffff);
+}
+
+.calendar-modal__body {
+  padding: 16px 16px 28px;
+  overflow-y: auto;
+}
+
+.calendar-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.calendar-modal__header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.calendar-modal__header ion-button {
+  --color: var(--text-muted, #8b95a1);
+  margin: 0;
 }
 
 /* ---------- 모바일 ---------- */

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
-import { IonButton, IonContent, IonFooter, IonPage, IonSpinner, IonText, IonToolbar } from '@ionic/react';
+import { IonButton, IonContent, IonFooter, IonIcon, IonModal, IonPage, IonSpinner, IonText, IonToolbar } from '@ionic/react';
+import { closeOutline } from 'ionicons/icons';
 import { Helmet } from 'react-helmet';
 import API_URL from '../config';
+import { cachedGet } from '../common/kvCache';
 import CommonHeader from '../common/CommonHeader';
 import useIsMobile from '../common/useIsMobile';
 import { COMPANY_COLORS, COMPANY_NAMES } from '../common/companies';
@@ -20,7 +22,6 @@ interface CalendarJob {
   jobDetailLink: string;
   endDate: string;
   endTime: string | null;
-  closed: boolean;
 }
 
 interface CalendarDay {
@@ -71,15 +72,30 @@ const shiftMonth = ({ year, month }: TargetMonth, delta: number): TargetMonth =>
 };
 
 /**
+ * "yyyy-MM-dd HH:mm:ss" 를 Date 로. 사파리는 공백으로 구분된 형식을 못 읽어 T 로 바꿔 준다.
+ * 마감 여부를 서버가 아니라 여기서 판정하는 이유: 서버 응답에 "지금" 기준 값이 들어가면
+ * 응답을 캐싱할 수 없다.
+ */
+const parseEndDate = (endDate: string): Date | null => {
+  const parsed = new Date(endDate.replace(' ', 'T'));
+  return isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const isClosed = (job: CalendarJob, nowMs: number): boolean => {
+  const end = parseEndDate(job.endDate);
+  return end !== null && end.getTime() < nowMs;
+};
+
+/**
  * 처음 열었을 때 펼쳐 둘 날짜.
  * 아직 지원할 수 있는 공고가 남은 가장 이른 날을 고른다. 오늘이라도 그날 마감이 이미
  * 다 지났으면 건너뛴다. 그런 날이 없으면(지난 달 조회) 그 달 첫 마감일.
  */
-const pickDefaultDate = (month: CalendarMonth): string | null => {
+const pickDefaultDate = (month: CalendarMonth, nowMs: number): string | null => {
   if (month.days.length === 0) {
     return null;
   }
-  const open = month.days.find((day) => day.jobs.some((job) => !job.closed));
+  const open = month.days.find((day) => day.jobs.some((job) => !isClosed(job, nowMs)));
   return (open ?? month.days[0]).date;
 };
 
@@ -97,6 +113,8 @@ const Calendar: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [hasError, setHasError] = useState<boolean>(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  // 모바일은 2단 배치가 안 들어가 팝업으로 띄운다. PC 는 오른쪽 패널에 항상 붙어 있다.
+  const [isDetailOpen, setIsDetailOpen] = useState<boolean>(false);
 
   useEffect(() => {
     // 달/회사를 빠르게 바꾸면 먼저 보낸 요청이 늦게 도착해 화면을 덮을 수 있어 취소 플래그를 둔다.
@@ -106,13 +124,15 @@ const Calendar: React.FC = () => {
       setLoading(true);
       setHasError(false);
       try {
-        // 마감 여부(closed)는 시시각각 바뀌므로 KV 캐시를 타지 않고 원본 API 에서 받는다.
-        const response = await axios.get<CalendarMonth>(`${API_URL}/api/calendar/deadlines`, {
-          params: { year: target.year, month: target.month, company },
-        });
+        // 목록과 같은 KV 캐시를 탄다. 응답에 "지금" 기준 값이 없어 캐싱해도 안전하다.
+        const month = await cachedGet<CalendarMonth>(
+          `nklcb:calendar:${company}:${target.year}-${pad(target.month)}`,
+          `${API_URL}/api/calendar/deadlines`,
+          { year: String(target.year), month: String(target.month), company },
+        );
         if (cancelled) return;
-        setData(response.data);
-        setSelectedDate(pickDefaultDate(response.data));
+        setData(month);
+        setSelectedDate(pickDefaultDate(month, Date.now()));
       } catch (error) {
         if (cancelled) return;
         console.error('캘린더 조회 실패:', error);
@@ -137,6 +157,19 @@ const Calendar: React.FC = () => {
 
   const selectedDay = selectedDate ? daysByDate.get(selectedDate) : undefined;
   const today = todayKey();
+  const nowMs = Date.now();
+
+  const handleDayClick = (dateKey: string) => {
+    setSelectedDate(dateKey);
+    if (isMobile) {
+      setIsDetailOpen(true);
+    }
+  };
+
+  const goToMonth = (delta: number) => {
+    // 연속으로 빠르게 눌러도 한 달만 움직이지 않도록 이전 상태에서 계산한다.
+    setTarget((prev) => shiftMonth(prev, delta));
+  };
 
   const renderCells = (month: CalendarMonth) => {
     // 1일이 월요일이 아니면 그만큼 앞을 비운다.
@@ -165,20 +198,20 @@ const Calendar: React.FC = () => {
           className={classNames}
           key={dateKey}
           disabled={!day}
-          onClick={() => setSelectedDate(dateKey)}
+          onClick={() => handleDayClick(dateKey)}
           aria-label={day ? `${month.month}월 ${dayNumber}일 마감 ${day.count}건` : `${month.month}월 ${dayNumber}일`}
         >
           <span className="calendar-cell__day">{dayNumber}</span>
           {day && (isMobile ? (
             // 그날 공고가 전부 마감이면 배지도 흐리게 — 지난 달을 봐도 진행 중처럼 보이지 않게
-            <span className={`calendar-cell__count${day.jobs.every((job) => job.closed) ? ' calendar-cell__count--closed' : ''}`}>
+            <span className={`calendar-cell__count${day.jobs.every((job) => isClosed(job, nowMs)) ? ' calendar-cell__count--closed' : ''}`}>
               {day.count}
             </span>
           ) : (
             <span className="calendar-cell__chips">
               {day.jobs.slice(0, MAX_CHIPS_PER_CELL).map((job) => (
                 <span
-                  className={`calendar-chip${job.closed ? ' calendar-chip--closed' : ''}`}
+                  className={`calendar-chip${isClosed(job, nowMs) ? ' calendar-chip--closed' : ''}`}
                   key={job.id ?? `${job.companyCd}-${job.annoId}`}
                 >
                   <i className="calendar-chip__dot" style={{ backgroundColor: COMPANY_COLORS[job.companyCd] || 'var(--text-muted)' }} />
@@ -197,6 +230,48 @@ const Calendar: React.FC = () => {
     return [...blanks, ...cells];
   };
 
+  const dayTitle = (day: CalendarDay) =>
+    `${day.date.replace(/^\d{4}-0?(\d+)-0?(\d+)$/, '$1월 $2일')} (${WEEKDAYS[day.dayOfWeek - 1]}) 마감 ${day.count}건`;
+
+  const renderJobs = (day: CalendarDay) => (
+    <>
+      {day.jobs.map((job) => {
+        const closed = isClosed(job, nowMs);
+        return (
+          <div
+            className={`calendar-job${closed ? ' calendar-job--closed' : ''}`}
+            key={job.id ?? `${job.companyCd}-${job.annoId}`}
+          >
+            <span
+              className="calendar-job__bar"
+              style={{ backgroundColor: COMPANY_COLORS[job.companyCd] || 'var(--border)' }}
+            />
+            <div className="calendar-job__body">
+              <h3 className="calendar-job__title">
+                {job.annoSubject}
+                {closed && <span className="calendar-badge-closed">마감</span>}
+              </h3>
+              <p className="calendar-job__meta">
+                {job.companyNm}
+                {job.subJobCdNm ? ` | ${job.subJobCdNm}` : ''}
+                {job.endTime ? ` | ${job.endTime} 마감` : ''}
+                {job.workplace ? ` | ${job.workplace}` : ''}
+              </p>
+              <a
+                href={job.jobDetailLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => logJobClick(job)}
+              >
+                자세히 보기
+              </a>
+            </div>
+          </div>
+        );
+      })}
+    </>
+  );
+
   return (
     <IonPage>
       <Helmet>
@@ -209,12 +284,11 @@ const Calendar: React.FC = () => {
       <IonContent fullscreen>
         <div className="calendar-page">
           <div className="calendar-toolbar">
-            {/* 연속으로 빠르게 눌러도 한 달만 움직이지 않도록 이전 상태에서 계산한다 */}
-            <IonButton fill="clear" className="calendar-nav-btn" onClick={() => setTarget((prev) => shiftMonth(prev, -1))} aria-label="이전 달">
+            <IonButton fill="clear" className="calendar-nav-btn" onClick={() => goToMonth(-1)} aria-label="이전 달">
               &lsaquo;
             </IonButton>
             <h1 className="calendar-title">{target.year}년 {target.month}월</h1>
-            <IonButton fill="clear" className="calendar-nav-btn" onClick={() => setTarget((prev) => shiftMonth(prev, 1))} aria-label="다음 달">
+            <IonButton fill="clear" className="calendar-nav-btn" onClick={() => goToMonth(1)} aria-label="다음 달">
               &rsaquo;
             </IonButton>
             <IonButton size="small" fill="outline" className="calendar-today-btn" onClick={() => setTarget(thisMonth())}>
@@ -253,66 +327,67 @@ const Calendar: React.FC = () => {
                 <span className="calendar-summary__note">상시채용(영입종료시) 공고는 마감일이 없어 캘린더에 표시되지 않습니다.</span>
               </p>
 
-              <div className="calendar-grid">
-                {WEEKDAYS.map((label, index) => (
-                  <div
-                    className={`calendar-weekday${index === 5 ? ' calendar-weekday--saturday' : ''}${index === 6 ? ' calendar-weekday--sunday' : ''}`}
-                    key={label}
-                  >
-                    {label}
-                  </div>
-                ))}
-                {renderCells(data)}
-              </div>
-
-              {selectedDay ? (
-                <section className="calendar-detail">
-                  <h2 className="calendar-detail__title">
-                    {selectedDay.date.replace(/^\d{4}-0?(\d+)-0?(\d+)$/, '$1월 $2일')} ({WEEKDAYS[selectedDay.dayOfWeek - 1]}) 마감 {selectedDay.count}건
-                  </h2>
-                  {selectedDay.jobs.map((job) => (
+              {/* PC: 왼쪽 달력 · 오른쪽 공고. 모바일: 달력만 두고 날짜를 누르면 팝업. */}
+              <div className="calendar-layout">
+                <div className="calendar-grid">
+                  {WEEKDAYS.map((label, index) => (
                     <div
-                      className={`calendar-job${job.closed ? ' calendar-job--closed' : ''}`}
-                      key={job.id ?? `${job.companyCd}-${job.annoId}`}
+                      className={`calendar-weekday${index === 5 ? ' calendar-weekday--saturday' : ''}${index === 6 ? ' calendar-weekday--sunday' : ''}`}
+                      key={label}
                     >
-                      <span
-                        className="calendar-job__bar"
-                        style={{ backgroundColor: COMPANY_COLORS[job.companyCd] || 'var(--border)' }}
-                      />
-                      <div className="calendar-job__body">
-                        <h3 className="calendar-job__title">
-                          {job.annoSubject}
-                          {job.closed && <span className="calendar-badge-closed">마감</span>}
-                        </h3>
-                        <p className="calendar-job__meta">
-                          {job.companyNm}
-                          {job.subJobCdNm ? ` | ${job.subJobCdNm}` : ''}
-                          {job.endTime ? ` | ${job.endTime} 마감` : ''}
-                          {job.workplace ? ` | ${job.workplace}` : ''}
-                        </p>
-                        <a
-                          href={job.jobDetailLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={() => logJobClick(job)}
-                        >
-                          자세히 보기
-                        </a>
-                      </div>
+                      {label}
                     </div>
                   ))}
-                </section>
-              ) : (
-                <div className="calendar-status">
-                  {data.totalCount === 0
-                    ? '이 달에 마감되는 공고가 없습니다.'
-                    : '날짜를 선택하면 그날 마감되는 공고를 볼 수 있습니다.'}
+                  {renderCells(data)}
                 </div>
+
+                {!isMobile && (
+                  <aside className="calendar-detail">
+                    {selectedDay ? (
+                      <>
+                        <h2 className="calendar-detail__title">{dayTitle(selectedDay)}</h2>
+                        {renderJobs(selectedDay)}
+                      </>
+                    ) : (
+                      <p className="calendar-detail__placeholder">
+                        {data.totalCount === 0
+                          ? '이 달에 마감되는 공고가 없습니다.'
+                          : '날짜를 선택하면 그날 마감되는 공고가 여기에 표시됩니다.'}
+                      </p>
+                    )}
+                  </aside>
+                )}
+              </div>
+
+              {isMobile && data.totalCount === 0 && (
+                <div className="calendar-status">이 달에 마감되는 공고가 없습니다.</div>
               )}
             </>
           )}
         </div>
       </IonContent>
+
+      {/* 모바일 전용 팝업. 날짜를 누르면 그날 공고가 시트로 올라온다. */}
+      <IonModal
+        isOpen={isMobile && isDetailOpen && !!selectedDay}
+        onDidDismiss={() => setIsDetailOpen(false)}
+        className="calendar-modal"
+        initialBreakpoint={0.75}
+        breakpoints={[0, 0.75, 1]}
+      >
+        {selectedDay && (
+          <div className="calendar-modal__body">
+            <header className="calendar-modal__header">
+              <h2>{dayTitle(selectedDay)}</h2>
+              <IonButton fill="clear" size="small" aria-label="닫기" onClick={() => setIsDetailOpen(false)}>
+                <IonIcon slot="icon-only" icon={closeOutline} />
+              </IonButton>
+            </header>
+            {renderJobs(selectedDay)}
+          </div>
+        )}
+      </IonModal>
+
       <IonFooter>
         <IonToolbar>
           <IonText className="footer-text">


### PR DESCRIPTION
## 왜

- 공고가 달력 **아래**에 있어 있는 줄도 모르고 지나친다.
- 목록 화면은 응답이 오기 전에 "데이터가 없습니다" + 채용 페이지 안내가 먼저 떠서, 공고가 없는 것처럼 보인다.

## 무엇

**캘린더 배치**
- PC: 왼쪽 달력 · 오른쪽 공고 패널(`sticky`). 달력을 스크롤해도 공고가 따라온다. 날짜를 안 골랐으면 안내 문구.
- 모바일: 2단이 안 들어가므로 날짜를 누르면 **바텀 시트 팝업**. 로그인이 PC 모달 / 모바일 페이지로 갈리는 것과 같은 방식.

**목록 로딩**
- 응답이 올 때까지 스피너 + "공고를 불러오는 중입니다…" 를 보여주고, "데이터가 없습니다"와 채용 페이지 안내는 응답 후에만 노출한다. (고정 2초 지연이 아니라 응답이 올 때까지 — 빨리 오면 바로 사라진다.)

**캐싱** (백엔드 PR kingle1024/nklcbdty-service#207 과 짝)
- 캘린더도 목록과 같은 KV 캐시(`cachedGet`)를 탄다. 달을 넘길 때마다 잠든 원본 서버를 깨우던 것을 없앤다.
- 마감 여부를 서버의 `closed` 대신 `endDate` 로 프론트에서 판정한다. 응답에 "지금" 기준 값이 있으면 캐싱이 stale 을 만들기 때문. 사파리가 못 읽는 `"yyyy-MM-dd HH:mm:ss"` 는 `T` 로 바꿔 파싱한다.
- 예전 응답(`closed` 포함)이 와도 무시하고 계산하므로 백엔드 배포 순서에 상관없이 동작한다.

## 확인

`tsc --noEmit` · `eslint` 통과(새 경고 0). API 스텁을 띄우고 dev 서버에서 확인:

- PC(1280px): 2단 레이아웃(`minmax(0,1fr) 360px`), 날짜 클릭 시 오른쪽 패널 갱신
- 모바일(375px): 사이드 패널 없음, 날짜 탭 → 팝업에 그날 공고 5건 + 닫기 버튼
- 지난 달: 칩 취소선 · 카드 흐리게 · `마감` 배지 (서버 `closed` 없이 프론트 계산으로 동작 확인)
- 목록 로딩: 요청 중 스피너만, 응답 후 카드 + 채용 페이지 버튼 (타임라인으로 확인)

> 시각적 레이아웃은 렌더링되는 브라우저에서 눈으로 확인하지 못했다(자동화 환경 제약). 배포 프리뷰로 봐 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)