### PR TITLE
✨ Feat: 채용 캘린더 상단 필터 — 검색·직무·채용형태·진행여부

### DIFF
--- a/src/pages/Calendar.css
+++ b/src/pages/Calendar.css
@@ -498,9 +498,22 @@
     min-width: 110px;
   }
 
-  /* 한 줄에 다 못 들어가니 검색은 한 줄 전체, 드롭다운은 2개씩 나눠 놓는다. */
+  /* 한 줄에 다 못 들어가니 검색은 한 줄 전체, 드롭다운은 2개씩 나눠 놓는다.
+     필터가 첫 화면을 다 먹으면 달력이 안 보이므로 줄 수를 최대한 줄인다. */
   .calendar-filters {
     padding: 10px;
+  }
+
+  /* 회사 칩은 두 줄로 접히는 대신 옆으로 넘긴다 (한 줄 = 약 44px 절약). */
+  .calendar-company-filter {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .calendar-company-filter::-webkit-scrollbar {
+    display: none;
   }
 
   .calendar-filters ion-searchbar.calendar-filters__search {
@@ -520,8 +533,9 @@
     text-align: right;
   }
 
+  /* 진행여부와 한 줄에 나란히 — 초기화 버튼 혼자 한 줄을 쓰지 않게. */
   .calendar-filters ion-button.calendar-filters__reset {
-    flex: 1 1 100%;
+    flex: 1 1 calc(50% - 4px);
     margin: 0;
   }
 }

--- a/src/pages/Calendar.css
+++ b/src/pages/Calendar.css
@@ -62,12 +62,88 @@
   --border-width: 1px;
 }
 
+/* ---------- 상단 필터 ---------- */
+.calendar-filters {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: 12px 14px;
+  margin-bottom: 16px;
+}
+
+.calendar-filters__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+/* 검색창은 남는 폭을 다 먹되, 드롭다운이 밀려나지 않게 최소폭을 준다. */
+.calendar-filters ion-searchbar.calendar-filters__search {
+  flex: 1 1 220px;
+  min-width: 180px;
+  padding: 0;
+  --background: var(--surface-field);
+  --box-shadow: none;
+  --border-radius: var(--radius-sm);
+  --placeholder-color: var(--text-muted);
+  --color: var(--text-body);
+  height: 38px;
+  font-size: 14px;
+}
+
+.calendar-select {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-field);
+}
+
+.calendar-select__label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.calendar-select select {
+  max-width: 160px;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-body);
+  cursor: pointer;
+  outline: none;
+}
+
+.calendar-select select:disabled {
+  color: var(--text-disabled);
+  cursor: default;
+}
+
+.calendar-filters ion-button.calendar-filters__reset {
+  margin: 0 0 0 auto;
+  height: 38px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: none;
+  --color: var(--text-secondary);
+}
+
 /* ---------- 회사 필터 (목록 화면과 같은 알약형 칩) ---------- */
 .calendar-company-filter {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 10px;
 }
 
 .calendar-company-filter ion-button {
@@ -93,6 +169,12 @@
 
 .calendar-summary strong {
   color: var(--brand-primary);
+}
+
+.calendar-summary__total {
+  margin-left: 6px;
+  font-size: 13px;
+  color: var(--text-muted);
 }
 
 .calendar-summary__note {
@@ -414,5 +496,32 @@
   .calendar-title {
     font-size: 18px;
     min-width: 110px;
+  }
+
+  /* 한 줄에 다 못 들어가니 검색은 한 줄 전체, 드롭다운은 2개씩 나눠 놓는다. */
+  .calendar-filters {
+    padding: 10px;
+  }
+
+  .calendar-filters ion-searchbar.calendar-filters__search {
+    flex: 1 1 100%;
+  }
+
+  .calendar-select {
+    flex: 1 1 calc(50% - 4px);
+    justify-content: space-between;
+    padding: 0 8px;
+  }
+
+  .calendar-select select {
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: none;
+    text-align: right;
+  }
+
+  .calendar-filters ion-button.calendar-filters__reset {
+    flex: 1 1 100%;
+    margin: 0;
   }
 }

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import axios from 'axios';
-import { IonButton, IonContent, IonFooter, IonIcon, IonModal, IonPage, IonSpinner, IonText, IonToolbar } from '@ionic/react';
+import { IonButton, IonContent, IonFooter, IonIcon, IonModal, IonPage, IonSearchbar, IonSpinner, IonText, IonToolbar } from '@ionic/react';
 import { closeOutline } from 'ionicons/icons';
 import { Helmet } from 'react-helmet';
 import API_URL from '../config';
@@ -45,6 +45,25 @@ interface TargetMonth {
   month: number;
 }
 
+/** 상단 필터 상태. 회사만 서버 조회 조건이고, 나머지는 받아 온 그 달 안에서 걸러낸다. */
+interface CalendarFilters {
+  keyword: string;
+  subJob: string;
+  empType: string;
+  status: JobStatus;
+}
+
+/** 진행여부. OPEN = 아직 마감 전, CLOSED = 이미 마감. */
+type JobStatus = 'ALL' | 'OPEN' | 'CLOSED';
+
+const STATUS_LABELS: { value: JobStatus; label: string }[] = [
+  { value: 'ALL', label: '전체' },
+  { value: 'OPEN', label: '진행 중' },
+  { value: 'CLOSED', label: '마감' },
+];
+
+const EMPTY_FILTERS: CalendarFilters = { keyword: '', subJob: '', empType: '', status: 'ALL' };
+
 /** 달력은 월요일 시작. 서버의 dayOfWeek(1=월 ~ 7=일)와 인덱스를 맞춘다. */
 const WEEKDAYS = ['월', '화', '수', '목', '금', '토', '일'];
 
@@ -86,6 +105,57 @@ const isClosed = (job: CalendarJob, nowMs: number): boolean => {
   return end !== null && end.getTime() < nowMs;
 };
 
+const isFilterActive = (filters: CalendarFilters): boolean =>
+  filters.keyword.trim() !== '' || filters.subJob !== '' || filters.empType !== '' || filters.status !== 'ALL';
+
+const matchesFilters = (job: CalendarJob, filters: CalendarFilters, nowMs: number): boolean => {
+  if (filters.subJob && job.subJobCdNm !== filters.subJob) return false;
+  if (filters.empType && job.empTypeCdNm !== filters.empType) return false;
+  if (filters.status !== 'ALL' && isClosed(job, nowMs) !== (filters.status === 'CLOSED')) return false;
+
+  const keyword = filters.keyword.trim().toLowerCase();
+  if (!keyword) return true;
+  return [job.annoSubject, job.companyNm, job.subJobCdNm, job.workplace]
+    .some((field) => field != null && field.toLowerCase().includes(keyword));
+};
+
+/**
+ * 필터를 통과한 공고만 남긴 달. 건수(day.count, totalCount)도 남은 공고 기준으로 다시 센다.
+ * 서버 조회 없이 받아 온 달 안에서만 걸러내므로 드롭다운을 바꿔도 화면이 바로 반응한다.
+ */
+const applyFilters = (month: CalendarMonth, filters: CalendarFilters, nowMs: number): CalendarMonth => {
+  if (!isFilterActive(filters)) {
+    return month;
+  }
+  const days = month.days
+    .map((day) => {
+      const jobs = day.jobs.filter((job) => matchesFilters(job, filters, nowMs));
+      return { ...day, jobs, count: jobs.length };
+    })
+    .filter((day) => day.count > 0);
+
+  return { ...month, days, totalCount: days.reduce((sum, day) => sum + day.count, 0) };
+};
+
+/**
+ * 드롭다운에 채울 값 목록. 그 달에 실제로 있는 값만 뽑는다.
+ * 고른 값이 이번 달에 없어도 목록에 남겨 둔다 — 달을 넘길 때마다 선택이 풀리면
+ * "프론트엔드 공고가 언제 마감되나" 를 달력으로 훑을 수가 없다.
+ */
+const collectOptions = (
+  month: CalendarMonth | null,
+  pick: (job: CalendarJob) => string | null,
+  selected: string,
+): string[] => {
+  const values = new Set<string>();
+  month?.days.forEach((day) => day.jobs.forEach((job) => {
+    const value = pick(job);
+    if (value) values.add(value);
+  }));
+  if (selected) values.add(selected);
+  return Array.from(values).sort((a, b) => a.localeCompare(b, 'ko'));
+};
+
 /**
  * 처음 열었을 때 펼쳐 둘 날짜.
  * 아직 지원할 수 있는 공고가 남은 가장 이른 날을 고른다. 오늘이라도 그날 마감이 이미
@@ -109,7 +179,9 @@ const Calendar: React.FC = () => {
   const isMobile = useIsMobile();
   const [target, setTarget] = useState<TargetMonth>(thisMonth);
   const [company, setCompany] = useState<string>('ALL');
+  const [filters, setFilters] = useState<CalendarFilters>(EMPTY_FILTERS);
   const [data, setData] = useState<CalendarMonth | null>(null);
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
   const [loading, setLoading] = useState<boolean>(true);
   const [hasError, setHasError] = useState<boolean>(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
@@ -131,8 +203,10 @@ const Calendar: React.FC = () => {
           { year: String(target.year), month: String(target.month), company },
         );
         if (cancelled) return;
+        // 마감 판정 기준 시각을 여기서 한 번만 잡는다. 렌더마다 Date.now() 를 새로 부르면
+        // 아래 useMemo 들이 매 렌더 다시 돈다.
+        setNowMs(Date.now());
         setData(month);
-        setSelectedDate(pickDefaultDate(month, Date.now()));
       } catch (error) {
         if (cancelled) return;
         console.error('캘린더 조회 실패:', error);
@@ -149,21 +223,51 @@ const Calendar: React.FC = () => {
     };
   }, [target, company]);
 
+  // 화면에 그리는 건 필터를 통과한 달. 원본(data)은 "전체 N건 중" 안내와 드롭다운 목록에만 쓴다.
+  const filtered = useMemo(() => (data ? applyFilters(data, filters, nowMs) : null), [data, filters, nowMs]);
+  const filterActive = isFilterActive(filters);
+
+  const subJobOptions = useMemo(
+    () => collectOptions(data, (job) => job.subJobCdNm, filters.subJob),
+    [data, filters.subJob],
+  );
+  const empTypeOptions = useMemo(
+    () => collectOptions(data, (job) => job.empTypeCdNm, filters.empType),
+    [data, filters.empType],
+  );
+
   const daysByDate = useMemo(() => {
     const map = new Map<string, CalendarDay>();
-    data?.days.forEach((day) => map.set(day.date, day));
+    filtered?.days.forEach((day) => map.set(day.date, day));
     return map;
-  }, [data]);
+  }, [filtered]);
+
+  // 달이나 필터가 바뀌어 펼쳐 둔 날짜가 사라졌으면 남은 날짜로 옮긴다.
+  useEffect(() => {
+    setSelectedDate((prev) => {
+      if (!filtered) return null;
+      if (prev && filtered.days.some((day) => day.date === prev)) return prev;
+      return pickDefaultDate(filtered, nowMs);
+    });
+  }, [filtered, nowMs]);
 
   const selectedDay = selectedDate ? daysByDate.get(selectedDate) : undefined;
   const today = todayKey();
-  const nowMs = Date.now();
+
+  // 빈 화면일 때 "이 달에 없는 것"과 "필터에 걸러진 것"을 구분해 준다.
+  const emptyMessage = filtered && filtered.totalCount === 0
+    ? (filterActive ? '필터 조건에 맞는 공고가 없습니다.' : '이 달에 마감되는 공고가 없습니다.')
+    : '날짜를 선택하면 그날 마감되는 공고가 여기에 표시됩니다.';
 
   const handleDayClick = (dateKey: string) => {
     setSelectedDate(dateKey);
     if (isMobile) {
       setIsDetailOpen(true);
     }
+  };
+
+  const updateFilter = (patch: Partial<CalendarFilters>) => {
+    setFilters((prev) => ({ ...prev, ...patch }));
   };
 
   const goToMonth = (delta: number) => {
@@ -296,17 +400,80 @@ const Calendar: React.FC = () => {
             </IonButton>
           </div>
 
-          <div className="calendar-company-filter">
-            {Object.keys(COMPANY_NAMES).map((companyCd) => (
+          {/* 상단 필터. 회사만 서버에 넘기고(달마다 캐시된다) 나머지는 받아 온 달 안에서 걸러낸다. */}
+          <section className="calendar-filters" aria-label="공고 필터">
+            <div className="calendar-company-filter">
+              {Object.keys(COMPANY_NAMES).map((companyCd) => (
+                <IonButton
+                  key={companyCd}
+                  onClick={() => setCompany(companyCd)}
+                  color={company === companyCd ? 'primary' : 'medium'}
+                >
+                  {COMPANY_NAMES[companyCd]}
+                </IonButton>
+              ))}
+            </div>
+
+            <div className="calendar-filters__row">
+              <IonSearchbar
+                className="calendar-filters__search"
+                value={filters.keyword}
+                onIonInput={(e) => updateFilter({ keyword: e.detail.value || '' })}
+                placeholder="공고명, 직무, 근무지 검색"
+                debounce={0}
+              />
+
+              <label className="calendar-select">
+                <span className="calendar-select__label">직무</span>
+                <select
+                  value={filters.subJob}
+                  onChange={(e) => updateFilter({ subJob: e.target.value })}
+                  disabled={subJobOptions.length === 0}
+                >
+                  <option value="">전체</option>
+                  {subJobOptions.map((option) => (
+                    <option key={option} value={option}>{option}</option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="calendar-select">
+                <span className="calendar-select__label">채용형태</span>
+                <select
+                  value={filters.empType}
+                  onChange={(e) => updateFilter({ empType: e.target.value })}
+                  disabled={empTypeOptions.length === 0}
+                >
+                  <option value="">전체</option>
+                  {empTypeOptions.map((option) => (
+                    <option key={option} value={option}>{option}</option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="calendar-select">
+                <span className="calendar-select__label">진행여부</span>
+                <select
+                  value={filters.status}
+                  onChange={(e) => updateFilter({ status: e.target.value as JobStatus })}
+                >
+                  {STATUS_LABELS.map(({ value, label }) => (
+                    <option key={value} value={value}>{label}</option>
+                  ))}
+                </select>
+              </label>
+
               <IonButton
-                key={companyCd}
-                onClick={() => setCompany(companyCd)}
-                color={company === companyCd ? 'primary' : 'medium'}
+                size="small"
+                fill="clear"
+                className="calendar-filters__reset"
+                disabled={!filterActive}
+                onClick={() => setFilters(EMPTY_FILTERS)}
               >
-                {COMPANY_NAMES[companyCd]}
+                필터 초기화
               </IonButton>
-            ))}
-          </div>
+            </div>
+          </section>
 
           {loading && (
             <div className="calendar-status">
@@ -320,10 +487,11 @@ const Calendar: React.FC = () => {
             </div>
           )}
 
-          {!loading && !hasError && data && (
+          {!loading && !hasError && data && filtered && (
             <>
               <p className="calendar-summary">
-                {data.month}월에 마감되는 공고 <strong>{data.totalCount}건</strong>
+                {filtered.month}월에 마감되는 공고 <strong>{filtered.totalCount}건</strong>
+                {filterActive && <span className="calendar-summary__total">(필터 없이 {data.totalCount}건)</span>}
                 <span className="calendar-summary__note">상시채용(영입종료시) 공고는 마감일이 없어 캘린더에 표시되지 않습니다.</span>
               </p>
 
@@ -338,7 +506,7 @@ const Calendar: React.FC = () => {
                       {label}
                     </div>
                   ))}
-                  {renderCells(data)}
+                  {renderCells(filtered)}
                 </div>
 
                 {!isMobile && (
@@ -349,18 +517,14 @@ const Calendar: React.FC = () => {
                         {renderJobs(selectedDay)}
                       </>
                     ) : (
-                      <p className="calendar-detail__placeholder">
-                        {data.totalCount === 0
-                          ? '이 달에 마감되는 공고가 없습니다.'
-                          : '날짜를 선택하면 그날 마감되는 공고가 여기에 표시됩니다.'}
-                      </p>
+                      <p className="calendar-detail__placeholder">{emptyMessage}</p>
                     )}
                   </aside>
                 )}
               </div>
 
-              {isMobile && data.totalCount === 0 && (
-                <div className="calendar-status">이 달에 마감되는 공고가 없습니다.</div>
+              {isMobile && filtered.totalCount === 0 && (
+                <div className="calendar-status">{emptyMessage}</div>
               )}
             </>
           )}


### PR DESCRIPTION
회사 탭만으로는 "내 직무 공고가 언제 마감되나"를 달력에서 찾을 수 없었습니다. 회사 칩 아래에 필터 줄을 붙여 좁혀 볼 수 있게 했습니다.

## 추가한 필터
- **검색어** — 공고명 · 회사 · 직무 · 근무지
- **직무**(`subJobCdNm`) / **채용형태**(`empTypeCdNm`) — 그 달 데이터에 실제로 있는 값만 뽑아 채웁니다
- **진행여부** — 전체 / 진행 중 / 마감
- **필터 초기화** — 필터가 걸렸을 때만 활성

## 설계 판단
- 회사만 기존대로 서버 파라미터로 보내고(캐시 키가 `company:yearMonth`), 나머지는 받아 온 달 안에서 걸러냅니다. 재조회가 없어 즉시 반응하고 캐시 키가 늘지 않습니다. **백엔드 변경 없음.**
- 날짜별 건수·총 건수를 걸러낸 뒤 다시 셉니다. 필터가 걸리면 요약에 `(필터 없이 N건)`을 덧붙입니다.
- 고른 직무가 다음 달에 없어도 선택을 유지합니다 — "UX 디자인 공고가 언제 마감되나"를 달을 넘겨가며 훑는 게 이 화면의 주 용도라서입니다.
- 결과가 0건이면 "이 달에 마감되는 공고가 없습니다"와 "필터 조건에 맞는 공고가 없습니다"를 구분해 안내합니다.
- 펼쳐 둔 날짜가 필터로 사라지면 남은 날짜 중 가장 이른 진행 중인 날로 옮깁니다.
- 마감 판정 기준 시각(`nowMs`)을 조회 시점에 한 번만 잡도록 바꿨습니다. 렌더마다 `Date.now()`를 부르면 새로 넣은 `useMemo`들이 매 렌더 다시 돕니다.

## 모바일
375×812 에서 실제 렌더링을 확인했습니다. 처음엔 회사 칩 8개가 두 줄로 접히고 초기화 버튼이 한 줄을 차지해서 필터 카드가 첫 화면을 다 먹고 달력이 3주치만 보였습니다. 두 번째 커밋에서:

- 회사 칩은 모바일에서 줄바꿈 대신 가로 스크롤 (잘린 칩이 "더 있다"는 신호가 됩니다)
- 초기화 버튼은 진행여부와 한 줄에 반반으로

두 줄(약 90px)을 줄여 한 화면에 한 달 전체가 들어옵니다. 날짜 탭 → 바텀 시트, 마감 공고 흐림 처리도 그대로 동작합니다.

## 확인
`tsc --noEmit` 통과. 목 API + 개발 서버로 직무 필터(62→10건), 마감 필터, 검색어("해운대" → 16건 전부 부산 해운대구), 초기화, 달 이동·회사 전환 시 필터 유지, 모바일 레이아웃(스크린샷)을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar filtering by keyword, job type, employment type, company, and open or closed status.
  * Added search, filter controls, reset action, and unfiltered result totals.
  * Calendar counts, available options, selected dates, and details now update based on active filters.
  * Added responsive filter-panel layout and horizontally scrollable company selections on mobile.

* **Bug Fixes**
  * Improved consistency when displaying filtered results and closed-status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->