### PR TITLE
✨ Feat: 자유게시판 화면 — 목록·상세·작성/수정, 댓글

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,9 @@ import Email from './pages/EmailInquiry';
 import AdminHome from './pages/AdminHome';
 import AdminSubscriptions from './pages/AdminSubscriptions';
 import AdminJobDeleteRequests from './pages/AdminJobDeleteRequests';
+import Board from './pages/Board';
+import BoardDetail from './pages/BoardDetail';
+import BoardWrite from './pages/BoardWrite';
 
 setupIonicReact();
 const queryClient = new QueryClient();
@@ -56,6 +59,11 @@ const App: React.FC = () => {
               <Route path='/mypage' component={Mypage} exact={true} />
               <Route path='/login' component={Login} exact={true} />
               <Route path='/email' component={Email} exact={true} />
+              {/* 자유게시판. /board/write 가 /board/:id 보다 먼저 와야 'write' 가 글 id 로 잡히지 않는다 */}
+              <Route path='/board' component={Board} exact={true} />
+              <Route path='/board/write' component={BoardWrite} exact={true} />
+              <Route path='/board/:id/edit' component={BoardWrite} exact={true} />
+              <Route path='/board/:id' component={BoardDetail} exact={true} />
               <Route path='/admin' component={AdminHome} exact={true} />
               <Route path='/admin/subscriptions' component={AdminSubscriptions} exact={true} />
               <Route path='/admin/job-delete-requests' component={AdminJobDeleteRequests} exact={true} />

--- a/src/common/CommonHeader.tsx
+++ b/src/common/CommonHeader.tsx
@@ -31,6 +31,7 @@ const CommonHeader: React.FC = () => {
         <IonTitle onClick={handleTitleClick} style={{ cursor: 'pointer' }}>네카라쿠배당토야</IonTitle>
         <IonButtons slot='end'>
           <IonButton routerLink="/calendar">채용 캘린더</IonButton>
+          <IonButton routerLink="/board">자유게시판</IonButton>
           <IonButton routerLink="/email">문의 및 건의사항</IonButton>
           {isLoggedIn ? (
             <>

--- a/src/common/boardApi.ts
+++ b/src/common/boardApi.ts
@@ -1,0 +1,152 @@
+// 자유게시판 API 호출. 백엔드 BoardController(/api/board/**) 와 짝을 이룬다.
+// 목록/상세는 비로그인도 볼 수 있고, 작성/수정/삭제는 토큰이 있어야 한다.
+// (상세도 토큰을 함께 보낸다 — 서버가 mine 값을 채워줘야 수정/삭제 버튼을 띄울 수 있다)
+import axios from 'axios';
+import API_URL from '../config';
+
+export interface BoardPostSummary {
+  id: number;
+  title: string;
+  authorName: string | null;
+  viewCount: number;
+  commentCount: number;
+  insertDts: string | null;
+}
+
+export interface BoardPostPage {
+  items: BoardPostSummary[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface BoardComment {
+  id: number;
+  content: string;
+  authorName: string | null;
+  insertDts: string | null;
+  /** 내가 쓴 댓글인지 — 삭제 버튼 표시용 */
+  mine: boolean;
+}
+
+export interface BoardPostDetail {
+  id: number;
+  title: string;
+  content: string;
+  authorName: string | null;
+  viewCount: number;
+  commentCount: number;
+  insertDts: string | null;
+  updateDts: string | null;
+  /** 내가 쓴 글인지 — 수정/삭제 버튼 표시용 */
+  mine: boolean;
+  comments: BoardComment[];
+}
+
+const authHeaders = (): Record<string, string> => {
+  const token = localStorage.getItem('jwtToken');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+/** 서버가 돌려준 사용자용 메세지를 꺼낸다. 없으면 기본 문구. */
+const messageOf = (error: unknown, fallback: string): string => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { message?: string } | undefined;
+    if (data?.message) {
+      return data.message;
+    }
+    if (!error.response) {
+      return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.';
+    }
+  }
+  return fallback;
+};
+
+export const fetchPosts = async (page: number, size: number, keyword: string): Promise<BoardPostPage> => {
+  try {
+    const res = await axios.get<BoardPostPage>(`${API_URL}/api/board/posts`, {
+      params: keyword ? { page, size, keyword } : { page, size },
+    });
+    return res.data;
+  } catch (error) {
+    throw new Error(messageOf(error, '글 목록을 가져오지 못했습니다.'));
+  }
+};
+
+export const fetchPost = async (id: number): Promise<BoardPostDetail> => {
+  try {
+    const res = await axios.get<BoardPostDetail>(`${API_URL}/api/board/posts/${id}`, {
+      headers: authHeaders(),
+    });
+    return res.data;
+  } catch (error) {
+    throw new Error(messageOf(error, '글을 가져오지 못했습니다.'));
+  }
+};
+
+export const createPost = async (title: string, content: string): Promise<number> => {
+  try {
+    const res = await axios.post<{ id: number }>(
+      `${API_URL}/api/board/posts`,
+      { title, content },
+      { headers: authHeaders() }
+    );
+    return res.data.id;
+  } catch (error) {
+    throw new Error(messageOf(error, '글을 등록하지 못했습니다.'));
+  }
+};
+
+export const updatePost = async (id: number, title: string, content: string): Promise<void> => {
+  try {
+    await axios.put(`${API_URL}/api/board/posts/${id}`, { title, content }, { headers: authHeaders() });
+  } catch (error) {
+    throw new Error(messageOf(error, '글을 수정하지 못했습니다.'));
+  }
+};
+
+export const deletePost = async (id: number): Promise<void> => {
+  try {
+    await axios.delete(`${API_URL}/api/board/posts/${id}`, { headers: authHeaders() });
+  } catch (error) {
+    throw new Error(messageOf(error, '글을 삭제하지 못했습니다.'));
+  }
+};
+
+export const addComment = async (postId: number, content: string): Promise<void> => {
+  try {
+    await axios.post(`${API_URL}/api/board/posts/${postId}/comments`, { content }, { headers: authHeaders() });
+  } catch (error) {
+    throw new Error(messageOf(error, '댓글을 등록하지 못했습니다.'));
+  }
+};
+
+export const deleteComment = async (commentId: number): Promise<void> => {
+  try {
+    await axios.delete(`${API_URL}/api/board/comments/${commentId}`, { headers: authHeaders() });
+  } catch (error) {
+    throw new Error(messageOf(error, '댓글을 삭제하지 못했습니다.'));
+  }
+};
+
+/** 목록/상세에 쓰는 날짜 표기. 오늘 쓴 글은 시:분, 그 외는 연.월.일 */
+export const formatBoardDate = (value: string | null): string => {
+  if (!value) {
+    return '-';
+  }
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return value;
+  }
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const today = new Date();
+  const isToday =
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate();
+  if (isToday) {
+    return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  }
+  return `${date.getFullYear()}.${pad(date.getMonth() + 1)}.${pad(date.getDate())}`;
+};

--- a/src/pages/Board.css
+++ b/src/pages/Board.css
@@ -159,7 +159,7 @@
   font-size: 22px;
   font-weight: 700;
   color: var(--text-strong);
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .board-detail-meta {
@@ -179,7 +179,7 @@
   color: var(--text-body);
   /* 작성자가 넣은 줄바꿈을 그대로 보여준다 */
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .board-detail-actions {
@@ -233,7 +233,7 @@
   line-height: 1.6;
   color: var(--text-body);
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .board-comment-form {

--- a/src/pages/Board.css
+++ b/src/pages/Board.css
@@ -1,0 +1,323 @@
+/* 자유게시판(목록/상세/작성) 공통 스타일. 색/모양은 theme.css 의 토큰을 그대로 쓴다. */
+.board-container {
+  padding: 20px;
+  background-color: var(--surface-bg);
+  min-height: 100%;
+  box-sizing: border-box;
+}
+
+.board-card {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.board-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.board-head h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.board-subtitle {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.board-search {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.board-search input {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--text-body);
+  background-color: var(--surface-field);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+}
+
+.board-search input:focus {
+  border-color: var(--brand-primary);
+}
+
+/* 목록 */
+.board-list {
+  border-top: 1px solid var(--border);
+}
+
+.board-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 4px;
+  border-bottom: 1px solid var(--divider);
+  cursor: pointer;
+}
+
+.board-row:hover {
+  background-color: var(--surface-field);
+}
+
+.board-row-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.board-comment-badge {
+  margin-left: 6px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--brand-primary);
+}
+
+.board-row-meta {
+  display: flex;
+  gap: 12px;
+  flex: 0 0 auto;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.board-row-author {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.board-empty {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+/* 페이징 */
+.board-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 20px;
+  flex-wrap: wrap;
+}
+
+.board-page-btn {
+  min-width: 34px;
+  height: 34px;
+  padding: 0 8px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.board-page-btn:disabled {
+  color: var(--text-disabled);
+  cursor: default;
+}
+
+.board-page-btn.current {
+  color: #ffffff;
+  background-color: var(--brand-primary);
+  border-color: var(--brand-primary);
+  font-weight: 700;
+}
+
+/* 상세 */
+.board-detail-title {
+  margin: 0 0 8px;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-strong);
+  word-break: break-word;
+}
+
+.board-detail-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.board-detail-content {
+  padding: 20px 0;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--text-body);
+  /* 작성자가 넣은 줄바꿈을 그대로 보여준다 */
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.board-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-bottom: 8px;
+}
+
+/* 댓글 */
+.board-comments {
+  margin-top: 8px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+
+.board-comments h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.board-comment {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--divider);
+}
+
+.board-comment-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.board-comment-meta {
+  margin-bottom: 4px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.board-comment-author {
+  margin-right: 8px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.board-comment-text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-body);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.board-comment-form {
+  margin-top: 16px;
+}
+
+.board-login-hint {
+  margin-top: 16px;
+  padding: 16px;
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-muted);
+  background-color: var(--surface-field);
+  border-radius: var(--radius-sm);
+}
+
+/* 작성/수정 폼 */
+.board-field {
+  margin-bottom: 16px;
+}
+
+.board-field label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.board-field input,
+.board-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px;
+  font-size: 15px;
+  font-family: inherit;
+  line-height: 1.6;
+  color: var(--text-body);
+  background-color: var(--surface-field);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  resize: vertical;
+}
+
+.board-field input:focus,
+.board-field textarea:focus {
+  border-color: var(--brand-primary);
+}
+
+.board-field-count {
+  margin-top: 4px;
+  text-align: right;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.board-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 640px) {
+  .board-container {
+    padding: 12px;
+  }
+
+  .board-card {
+    padding: 16px;
+  }
+
+  /* 좁은 화면에서는 조회수를 빼고 작성자/날짜만 남긴다 */
+  .board-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .board-row-title {
+    white-space: normal;
+  }
+
+  .board-row-views {
+    display: none;
+  }
+}

--- a/src/pages/Board.tsx
+++ b/src/pages/Board.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { IonPage, IonContent, IonButton, IonSpinner, IonAlert } from '@ionic/react';
+import { Helmet } from 'react-helmet';
+import CommonHeader from '../common/CommonHeader';
+import { useAuth } from '../common/AuthContextType';
+import { BoardPostPage, fetchPosts, formatBoardDate } from '../common/boardApi';
+import './Board.css';
+
+const PAGE_SIZE = 20;
+
+/** 페이징 버튼에 보여줄 페이지 번호 목록(현재 페이지 기준 최대 5개) */
+const pageNumbers = (current: number, totalPages: number): number[] => {
+  const start = Math.max(0, Math.min(current - 2, totalPages - 5));
+  const end = Math.min(totalPages, start + 5);
+  const numbers: number[] = [];
+  for (let i = start; i < end; i += 1) {
+    numbers.push(i);
+  }
+  return numbers;
+};
+
+const Board: React.FC = () => {
+  const history = useHistory();
+  const { isLoggedIn } = useAuth();
+
+  const [result, setResult] = useState<BoardPostPage | null>(null);
+  const [page, setPage] = useState(0);
+  // 입력 중인 검색어와 실제 조회에 쓰는 검색어를 분리해 타이핑마다 조회하지 않는다
+  const [keywordInput, setKeywordInput] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      setResult(await fetchPosts(page, PAGE_SIZE, keyword));
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '글 목록을 가져오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, keyword]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSearch = () => {
+    setPage(0);
+    setKeyword(keywordInput.trim());
+  };
+
+  // 비로그인 사용자는 글을 쓸 수 없으므로 로그인 화면으로 안내한다
+  const handleWriteClick = () => {
+    if (!isLoggedIn) {
+      setErrorMessage('로그인 후 글을 작성할 수 있습니다.');
+      return;
+    }
+    history.push('/board/write');
+  };
+
+  const posts = result?.items ?? [];
+  const totalPages = result?.totalPages ?? 0;
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>자유게시판</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="취업/이직 이야기를 자유롭게 나누는 게시판" />
+      </Helmet>
+      <CommonHeader />
+      <IonContent>
+        <div className="board-container">
+          <div className="board-card">
+            <div className="board-head">
+              <h2>자유게시판</h2>
+              <IonButton size="small" onClick={handleWriteClick}>글쓰기</IonButton>
+            </div>
+            <p className="board-subtitle">취업·이직 준비 이야기를 자유롭게 나눠보세요.</p>
+
+            <div className="board-search">
+              <input
+                value={keywordInput}
+                onChange={(e) => setKeywordInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSearch();
+                  }
+                }}
+                placeholder="제목 또는 내용 검색"
+              />
+              <IonButton size="small" fill="outline" onClick={handleSearch}>검색</IonButton>
+            </div>
+
+            {isLoading ? (
+              <div className="board-empty"><IonSpinner name="crescent" /></div>
+            ) : posts.length === 0 ? (
+              <div className="board-empty">
+                {keyword ? `'${keyword}' 검색 결과가 없습니다.` : '첫 글을 남겨보세요.'}
+              </div>
+            ) : (
+              <div className="board-list">
+                {posts.map((post) => (
+                  <div
+                    key={post.id}
+                    className="board-row"
+                    onClick={() => history.push(`/board/${post.id}`)}
+                  >
+                    <div className="board-row-title">
+                      {post.title}
+                      {post.commentCount > 0 && (
+                        <span className="board-comment-badge">[{post.commentCount}]</span>
+                      )}
+                    </div>
+                    <div className="board-row-meta">
+                      <span className="board-row-author">{post.authorName ?? '알 수 없음'}</span>
+                      <span>{formatBoardDate(post.insertDts)}</span>
+                      <span className="board-row-views">조회 {post.viewCount}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {totalPages > 1 && (
+              <div className="board-pagination">
+                <button
+                  className="board-page-btn"
+                  disabled={page === 0}
+                  onClick={() => setPage(page - 1)}
+                >
+                  이전
+                </button>
+                {pageNumbers(page, totalPages).map((number) => (
+                  <button
+                    key={number}
+                    className={`board-page-btn${number === page ? ' current' : ''}`}
+                    onClick={() => setPage(number)}
+                  >
+                    {number + 1}
+                  </button>
+                ))}
+                <button
+                  className="board-page-btn"
+                  disabled={page >= totalPages - 1}
+                  onClick={() => setPage(page + 1)}
+                >
+                  다음
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <IonAlert
+          isOpen={!!errorMessage}
+          onDidDismiss={() => setErrorMessage('')}
+          header="알림"
+          message={errorMessage}
+          buttons={['확인']}
+        />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Board;

--- a/src/pages/BoardDetail.tsx
+++ b/src/pages/BoardDetail.tsx
@@ -1,0 +1,244 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { IonPage, IonContent, IonButton, IonSpinner, IonAlert } from '@ionic/react';
+import { Helmet } from 'react-helmet';
+import CommonHeader from '../common/CommonHeader';
+import { useAuth } from '../common/AuthContextType';
+import {
+  BoardPostDetail,
+  addComment,
+  deleteComment,
+  deletePost,
+  fetchPost,
+  formatBoardDate,
+} from '../common/boardApi';
+import './Board.css';
+
+const MAX_COMMENT_LENGTH = 1000;
+
+const BoardDetail: React.FC = () => {
+  const history = useHistory();
+  const { id } = useParams<{ id: string }>();
+  const postId = Number(id);
+  const { isLoggedIn } = useAuth();
+
+  const [post, setPost] = useState<BoardPostDetail | null>(null);
+  const [comment, setComment] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState('');
+  // 삭제는 되돌릴 수 없으므로 한 번 더 묻는다. 값이 있으면 확인창이 열린다.
+  const [pendingDelete, setPendingDelete] = useState<{ type: 'post' | 'comment'; id: number } | null>(null);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      setPost(await fetchPost(postId));
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : '글을 가져오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [postId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAddComment = async () => {
+    const content = comment.trim();
+    if (!content) {
+      setMessage('댓글 내용을 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await addComment(postId, content);
+      setComment('');
+      await load();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : '댓글을 등록하지 못했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!pendingDelete) {
+      return;
+    }
+    const target = pendingDelete;
+    setPendingDelete(null);
+
+    try {
+      if (target.type === 'post') {
+        await deletePost(target.id);
+        history.replace('/board');
+        return;
+      }
+      await deleteComment(target.id);
+      await load();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : '삭제하지 못했습니다.');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <IonPage>
+        <CommonHeader />
+        <IonContent>
+          <div className="board-container">
+            <div className="board-card">
+              <div className="board-empty"><IonSpinner name="crescent" /></div>
+            </div>
+          </div>
+        </IonContent>
+      </IonPage>
+    );
+  }
+
+  if (!post) {
+    return (
+      <IonPage>
+        <CommonHeader />
+        <IonContent>
+          <div className="board-container">
+            <div className="board-card">
+              <div className="board-empty">글을 찾을 수 없습니다.</div>
+              <div className="board-form-actions">
+                <IonButton size="small" fill="outline" onClick={() => history.replace('/board')}>
+                  목록으로
+                </IonButton>
+              </div>
+            </div>
+          </div>
+        </IonContent>
+        <IonAlert
+          isOpen={!!message}
+          onDidDismiss={() => setMessage('')}
+          header="알림"
+          message={message}
+          buttons={['확인']}
+        />
+      </IonPage>
+    );
+  }
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>{post.title} | 자유게시판</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Helmet>
+      <CommonHeader />
+      <IonContent>
+        <div className="board-container">
+          <div className="board-card">
+            <h2 className="board-detail-title">{post.title}</h2>
+            <div className="board-detail-meta">
+              <span>{post.authorName ?? '알 수 없음'}</span>
+              <span>{formatBoardDate(post.insertDts)}</span>
+              <span>조회 {post.viewCount}</span>
+              <span>댓글 {post.commentCount}</span>
+            </div>
+
+            <div className="board-detail-content">{post.content}</div>
+
+            <div className="board-detail-actions">
+              <IonButton size="small" fill="clear" onClick={() => history.push('/board')}>목록</IonButton>
+              {post.mine && (
+                <>
+                  <IonButton size="small" fill="outline" onClick={() => history.push(`/board/${post.id}/edit`)}>
+                    수정
+                  </IonButton>
+                  <IonButton
+                    size="small"
+                    fill="outline"
+                    color="danger"
+                    onClick={() => setPendingDelete({ type: 'post', id: post.id })}
+                  >
+                    삭제
+                  </IonButton>
+                </>
+              )}
+            </div>
+
+            <div className="board-comments">
+              <h3>댓글 {post.comments.length}</h3>
+              {post.comments.length === 0 ? (
+                <div className="board-empty">첫 댓글을 남겨보세요.</div>
+              ) : (
+                post.comments.map((item) => (
+                  <div key={item.id} className="board-comment">
+                    <div className="board-comment-body">
+                      <div className="board-comment-meta">
+                        <span className="board-comment-author">{item.authorName ?? '알 수 없음'}</span>
+                        <span>{formatBoardDate(item.insertDts)}</span>
+                      </div>
+                      <div className="board-comment-text">{item.content}</div>
+                    </div>
+                    {item.mine && (
+                      <IonButton
+                        size="small"
+                        fill="clear"
+                        color="danger"
+                        onClick={() => setPendingDelete({ type: 'comment', id: item.id })}
+                      >
+                        삭제
+                      </IonButton>
+                    )}
+                  </div>
+                ))
+              )}
+
+              {isLoggedIn ? (
+                <div className="board-comment-form">
+                  <div className="board-field">
+                    <textarea
+                      value={comment}
+                      maxLength={MAX_COMMENT_LENGTH}
+                      onChange={(e) => setComment(e.target.value)}
+                      placeholder="댓글을 입력하세요"
+                      rows={3}
+                    />
+                    <div className="board-field-count">{comment.length} / {MAX_COMMENT_LENGTH}</div>
+                  </div>
+                  <div className="board-form-actions">
+                    <IonButton size="small" onClick={handleAddComment} disabled={isSubmitting}>
+                      {isSubmitting ? '등록 중...' : '댓글 등록'}
+                    </IonButton>
+                  </div>
+                </div>
+              ) : (
+                <div className="board-login-hint">로그인 후 댓글을 작성할 수 있습니다.</div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <IonAlert
+          isOpen={!!pendingDelete}
+          onDidDismiss={() => setPendingDelete(null)}
+          header="삭제할까요?"
+          message={pendingDelete?.type === 'post' ? '글과 댓글이 함께 삭제됩니다.' : '댓글을 삭제합니다.'}
+          buttons={[
+            { text: '취소', role: 'cancel' },
+            { text: '삭제', role: 'destructive', handler: handleConfirmDelete },
+          ]}
+        />
+        <IonAlert
+          isOpen={!!message}
+          onDidDismiss={() => setMessage('')}
+          header="알림"
+          message={message}
+          buttons={['확인']}
+        />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default BoardDetail;

--- a/src/pages/BoardWrite.tsx
+++ b/src/pages/BoardWrite.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { IonPage, IonContent, IonButton, IonSpinner, IonAlert } from '@ionic/react';
+import { Helmet } from 'react-helmet';
+import CommonHeader from '../common/CommonHeader';
+import { useAuth } from '../common/AuthContextType';
+import { createPost, fetchPost, updatePost } from '../common/boardApi';
+import './Board.css';
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_CONTENT_LENGTH = 10000;
+
+/**
+ * 글 작성(/board/write)과 수정(/board/:id/edit)을 함께 처리한다.
+ * :id 가 있으면 수정 모드로 기존 내용을 불러온다.
+ */
+const BoardWrite: React.FC = () => {
+  const history = useHistory();
+  const { id } = useParams<{ id?: string }>();
+  const isEdit = !!id;
+  const postId = Number(id);
+  const { isLoggedIn } = useAuth();
+
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [isLoading, setIsLoading] = useState(isEdit);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState('');
+
+  // 비로그인 상태로 주소를 직접 열었을 때
+  useEffect(() => {
+    if (!isLoggedIn) {
+      history.replace('/login');
+    }
+  }, [isLoggedIn, history]);
+
+  const load = useCallback(async () => {
+    if (!isEdit) {
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const post = await fetchPost(postId);
+      // 남의 글 수정 주소를 직접 열었으면 상세로 되돌린다(서버도 작성자를 다시 확인한다)
+      if (!post.mine) {
+        history.replace(`/board/${postId}`);
+        return;
+      }
+      setTitle(post.title);
+      setContent(post.content);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : '글을 가져오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isEdit, postId, history]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      setMessage('제목을 입력해주세요.');
+      return;
+    }
+    if (!content.trim()) {
+      setMessage('내용을 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      if (isEdit) {
+        await updatePost(postId, title.trim(), content.trim());
+        history.replace(`/board/${postId}`);
+        return;
+      }
+      const newId = await createPost(title.trim(), content.trim());
+      history.replace(`/board/${newId}`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : '저장하지 못했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>{isEdit ? '글 수정' : '글쓰기'} | 자유게시판</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Helmet>
+      <CommonHeader />
+      <IonContent>
+        <div className="board-container">
+          <div className="board-card">
+            <div className="board-head">
+              <h2>{isEdit ? '글 수정' : '글쓰기'}</h2>
+            </div>
+
+            {isLoading ? (
+              <div className="board-empty"><IonSpinner name="crescent" /></div>
+            ) : (
+              <>
+                <div className="board-field">
+                  <label htmlFor="board-title">제목</label>
+                  <input
+                    id="board-title"
+                    value={title}
+                    maxLength={MAX_TITLE_LENGTH}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="제목을 입력하세요"
+                  />
+                  <div className="board-field-count">{title.length} / {MAX_TITLE_LENGTH}</div>
+                </div>
+
+                <div className="board-field">
+                  <label htmlFor="board-content">내용</label>
+                  <textarea
+                    id="board-content"
+                    value={content}
+                    maxLength={MAX_CONTENT_LENGTH}
+                    onChange={(e) => setContent(e.target.value)}
+                    placeholder="내용을 입력하세요"
+                    rows={14}
+                  />
+                  <div className="board-field-count">{content.length} / {MAX_CONTENT_LENGTH}</div>
+                </div>
+
+                <div className="board-form-actions">
+                  <IonButton
+                    size="small"
+                    fill="outline"
+                    onClick={() => (isEdit ? history.replace(`/board/${postId}`) : history.replace('/board'))}
+                  >
+                    취소
+                  </IonButton>
+                  <IonButton size="small" onClick={handleSubmit} disabled={isSubmitting}>
+                    {isSubmitting ? '저장 중...' : '저장'}
+                  </IonButton>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <IonAlert
+          isOpen={!!message}
+          onDidDismiss={() => setMessage('')}
+          header="알림"
+          message={message}
+          buttons={['확인']}
+        />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default BoardWrite;


### PR DESCRIPTION
## 왜

게시판이 아예 없었다. 백엔드 API(kingle1024/nklcbdty-service#208)와 짝을 이루는 화면.

## 무엇

헤더에 **자유게시판** 버튼을 추가하고 `/board` 아래에 화면 3개를 붙였다.

| 라우트 | 화면 |
|---|---|
| `/board` | 목록 — 검색, 페이징, 댓글 수 배지 |
| `/board/:id` | 상세 — 본문, 댓글 목록/작성, 본인 글이면 수정·삭제 |
| `/board/write`, `/board/:id/edit` | 작성 / 수정 (같은 컴포넌트) |

- `src/common/boardApi.ts` — API 호출 + 날짜 포맷
- `src/pages/Board.{tsx,css}`, `BoardDetail.tsx`, `BoardWrite.tsx`

## 봐주셨으면 하는 곳

- **라우트 순서** — `/board/write` 를 `/board/:id` 보다 먼저 둬야 한다. 그렇지 않으면 `write` 가 글 id 로 잡혀 상세 화면이 열린다.
- **상세 조회에도 토큰을 보낸다** — 서버가 `mine` 을 채워줘야 수정/삭제 버튼을 띄울 수 있다. 비로그인은 헤더 없이 보내고 `mine=false` 로 받는다.
- **작성/수정 겸용** — `:id` 가 있으면 수정 모드. 남의 글 수정 주소를 직접 열면 상세로 되돌린다(서버도 작성자를 다시 확인하므로 화면 처리는 편의용).
- 색·모양은 `theme.css` 토큰만 사용. 좁은 화면에서는 조회수를 숨긴다.
- 본문/댓글은 React 가 escape 하는 텍스트로만 렌더링한다(`white-space: pre-wrap` 으로 줄바꿈 유지). `dangerouslySetInnerHTML` 없음.

## 검증

- `tsc --noEmit` 통과
- 프로덕션 빌드(`CI=false NODE_ENV=production react-scripts build`) 성공
- `CI=true` 로도 돌려 확인 — 게시판 파일에서 나오는 lint 경고는 없다(기존 파일 경고만 남음)

## 참고

이 브랜치는 `origin/main` 에서 새로 따서 게시판 파일만 담았다. 로컬 `feat/local-auth-ui` 작업 트리에 있던 무관한 미커밋 변경(`Dockerfile`, `nginx.conf`, `public/_redirects`, `src/common/kvCache.ts`, `.gitattributes`, `docker/`)은 건드리지 않았고 그대로 남아 있다.

## 남겨둔 것

관리자 모더레이션 화면 없음 — 작성자 본인만 삭제 가능. 스팸 대응은 후속 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a free board with paginated post browsing and keyword search.
  * Added post detail pages with comments.
  * Added authenticated post creation, editing, and deletion.
  * Added comment submission and deletion with ownership controls.
  * Added board navigation to the main header.
  * Added responsive layouts, validation, loading states, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->