### PR TITLE
✨ Feat: 마이페이지에 나의 채용 캘린더

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import '@ionic/react/css/display.css';
 /* Theme variables */
 import './theme.css';
 import Mypage from './pages/Mypage';
+import MyCalendar from './pages/MyCalendar';
 import Calendar from './pages/Calendar';
 import Login from './pages/Login';
 import Email from './pages/EmailInquiry';
@@ -57,6 +58,8 @@ const App: React.FC = () => {
               <Route path='/' component={Home} exact={true} />
               <Route path='/calendar' component={Calendar} exact={true} />
               <Route path='/mypage' component={Mypage} exact={true} />
+              {/* 마이페이지 안의 나의 채용 캘린더. 로그인해야 쓸 수 있다. */}
+              <Route path='/mypage/calendar' component={MyCalendar} exact={true} />
               <Route path='/login' component={Login} exact={true} />
               <Route path='/email' component={Email} exact={true} />
               {/* 자유게시판. /board/write 가 /board/:id 보다 먼저 와야 'write' 가 글 id 로 잡히지 않는다 */}

--- a/src/common/Sidebar.tsx
+++ b/src/common/Sidebar.tsx
@@ -1,32 +1,33 @@
 import React from 'react';
 import { IonList, IonItem } from '@ionic/react';
+import { useHistory } from 'react-router-dom';
+
+/** 마이페이지 안의 메뉴. activeTab 은 각 페이지가 자기 값을 넘긴다. */
+const TABS = [
+  { key: 'profile', label: '내 정보', path: '/mypage' },
+  { key: 'calendar', label: '나의 채용 캘린더', path: '/mypage/calendar' },
+];
 
 interface SidebarProps {
   activeTab: string;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ activeTab }) => {
-  const handleTabClick = (tab: string) => {
-    if (tab === 'profile') {
-      window.location.href = '/mypage'; // 프로필 탭 클릭 시
-    } else if (tab === 'likes') {
-      window.location.href = '/mypage/likes'; // 좋아요 목록 탭 클릭 시
-    } else if (tab === 'addCourse') {
-      window.location.href = '/mypage/course/add'; // 데이트 코스 등록 클릭 시
-    }
-  };
-
+  const history = useHistory();
 
   return (
     <div className="sidebar">
       <IonList>
-        <IonItem
-          button
-          onClick={() => handleTabClick('profile')}
-          className={activeTab === 'profile' ? 'active' : ''}
-        >
-          내 정보
-        </IonItem>
+        {TABS.map((tab) => (
+          <IonItem
+            key={tab.key}
+            button
+            onClick={() => history.push(tab.path)}
+            className={activeTab === tab.key ? 'active' : ''}
+          >
+            {tab.label}
+          </IonItem>
+        ))}
       </IonList>
     </div>
   );

--- a/src/common/myCalendarApi.ts
+++ b/src/common/myCalendarApi.ts
@@ -1,0 +1,119 @@
+// 나의 채용 캘린더 API. 백엔드 MyCalendarController(/api/my-calendar/**) 와 짝을 이룬다.
+// 전부 로그인이 필요하다 — 서버에서 AuthFilter 가 토큰을 요구하고, 토큰이 없으면 401 이 온다.
+import axios from 'axios';
+import API_URL from '../config';
+
+export interface MyCalendarEntry {
+  id: number;
+  /** yyyy-MM-dd */
+  applyDate: string;
+  companyName: string;
+  url: string | null;
+  memo: string | null;
+}
+
+export interface MyCalendarDay {
+  date: string;
+  dayOfWeek: number;
+  count: number;
+  entries: MyCalendarEntry[];
+}
+
+export interface MyCalendarMonth {
+  year: number;
+  month: number;
+  firstDayOfWeek: number;
+  lengthOfMonth: number;
+  totalCount: number;
+  days: MyCalendarDay[];
+}
+
+export interface MyCalendarEntryInput {
+  applyDate: string;
+  companyName: string;
+  url: string;
+  memo: string;
+}
+
+const authHeaders = (): Record<string, string> => {
+  const token = localStorage.getItem('jwtToken');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+/** 서버가 돌려준 사용자용 메세지를 꺼낸다. 없으면 기본 문구. */
+const messageOf = (error: unknown, fallback: string): string => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { message?: string } | undefined;
+    if (data?.message) {
+      return data.message;
+    }
+    if (error.response?.status === 401) {
+      return '로그인이 필요합니다. 다시 로그인해 주세요.';
+    }
+    if (!error.response) {
+      return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.';
+    }
+  }
+  return fallback;
+};
+
+export const fetchMyCalendarMonth = async (year: number, month: number): Promise<MyCalendarMonth> => {
+  try {
+    const res = await axios.get<MyCalendarMonth>(`${API_URL}/api/my-calendar/entries`, {
+      params: { year, month },
+      headers: authHeaders(),
+    });
+    return res.data;
+  } catch (error) {
+    throw new Error(messageOf(error, '캘린더를 불러오지 못했습니다.'));
+  }
+};
+
+export const createMyCalendarEntry = async (input: MyCalendarEntryInput): Promise<MyCalendarEntry> => {
+  try {
+    const res = await axios.post<MyCalendarEntry>(`${API_URL}/api/my-calendar/entries`, input, {
+      headers: authHeaders(),
+    });
+    return res.data;
+  } catch (error) {
+    throw new Error(messageOf(error, '일정을 저장하지 못했습니다.'));
+  }
+};
+
+export const updateMyCalendarEntry = async (
+  id: number,
+  input: MyCalendarEntryInput,
+): Promise<MyCalendarEntry> => {
+  try {
+    const res = await axios.put<MyCalendarEntry>(`${API_URL}/api/my-calendar/entries/${id}`, input, {
+      headers: authHeaders(),
+    });
+    return res.data;
+  } catch (error) {
+    throw new Error(messageOf(error, '일정을 수정하지 못했습니다.'));
+  }
+};
+
+export const deleteMyCalendarEntry = async (id: number): Promise<void> => {
+  try {
+    await axios.delete(`${API_URL}/api/my-calendar/entries/${id}`, { headers: authHeaders() });
+  } catch (error) {
+    throw new Error(messageOf(error, '일정을 삭제하지 못했습니다.'));
+  }
+};
+
+/**
+ * URL 로 회사명을 추측한다. 입력 도우미일 뿐이라 실패해도 화면에 오류를 띄우지 않고
+ * 빈 값을 돌려준다 — 회사명은 사용자가 직접 적으면 된다.
+ */
+export const guessCompanyName = async (url: string): Promise<string> => {
+  try {
+    const res = await axios.get<{ companyName: string | null }>(
+      `${API_URL}/api/my-calendar/company-name`,
+      { params: { url }, headers: authHeaders() },
+    );
+    return res.data.companyName ?? '';
+  } catch {
+    return '';
+  }
+};

--- a/src/pages/MyCalendar.css
+++ b/src/pages/MyCalendar.css
@@ -1,0 +1,460 @@
+/*
+ * 나의 채용 캘린더 — 마이페이지 안에 들어가는 개인 일정 달력.
+ * 격자·칩 모양은 공개 채용 캘린더(Calendar.css)와 맞춰, 두 화면이 같은 달력으로 보이게 한다.
+ */
+
+/* ---------- 로그인 안내 ---------- */
+.mycal-login-gate {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 16px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.mycal-login-gate p {
+  margin: 0;
+}
+
+/* ---------- 상단 월 이동 ---------- */
+.mycal-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 16px 0 12px;
+}
+
+.mycal-title {
+  font-size: 18px;
+  font-weight: 800;
+  margin: 0;
+  min-width: 120px;
+  text-align: center;
+}
+
+.mycal-toolbar ion-button.mycal-nav-btn {
+  --color: var(--text-secondary);
+  --padding-start: 8px;
+  --padding-end: 8px;
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+.mycal-toolbar ion-button.mycal-today-btn {
+  margin-left: auto;
+  height: 32px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: none;
+  --border-radius: var(--radius-pill);
+  --border-width: 1px;
+}
+
+/* ---------- 요약 / 상태 ---------- */
+.mycal-summary {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0 0 12px;
+}
+
+.mycal-summary strong {
+  color: var(--brand-primary);
+}
+
+.mycal-summary__note {
+  display: block;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.mycal-status {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 120px;
+  font-size: 14px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* ---------- 2단 배치 ---------- */
+.mycal-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 16px;
+  align-items: start;
+}
+
+@media (max-width: 1180px) {
+  .mycal-layout {
+    grid-template-columns: minmax(0, 1fr) 280px;
+  }
+}
+
+/* 마이페이지 사이드바까지 있어 좁다. 이 아래로는 달력만 두고 일정은 팝업으로 띄운다. */
+@media (max-width: 900px) {
+  .mycal-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* ---------- 달력 그리드 ---------- */
+.mycal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px;
+}
+
+.mycal-weekday {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-align: center;
+  padding-bottom: 4px;
+}
+
+.mycal-weekday--saturday {
+  color: var(--brand-primary);
+}
+
+.mycal-weekday--sunday {
+  color: var(--danger);
+}
+
+/*
+ * 공개 캘린더와 달리 빈 날도 누를 수 있다 — 일정이 없는 날에 새로 적는 것이
+ * 이 화면의 주된 사용법이라 비활성으로 두면 안 된다.
+ */
+.mycal-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+  min-height: 92px;
+  padding: 6px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.mycal-cell--blank {
+  background: transparent;
+  cursor: default;
+}
+
+.mycal-cell:not(.mycal-cell--blank):hover {
+  border-color: var(--brand-primary);
+}
+
+.mycal-cell--selected {
+  border-color: var(--brand-primary);
+  background: var(--brand-primary-tint);
+}
+
+.mycal-cell__day {
+  align-self: flex-start;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-strong);
+  line-height: 18px;
+}
+
+.mycal-cell--saturday .mycal-cell__day {
+  color: var(--brand-primary);
+}
+
+.mycal-cell--sunday .mycal-cell__day {
+  color: var(--danger);
+}
+
+.mycal-cell--today .mycal-cell__day,
+.mycal-cell--today.mycal-cell--saturday .mycal-cell__day,
+.mycal-cell--today.mycal-cell--sunday .mycal-cell__day {
+  background: var(--brand-primary);
+  color: #fff;
+  border-radius: var(--radius-pill);
+  padding: 0 6px;
+}
+
+/* ---------- 셀 안의 일정 칩 (PC) ---------- */
+.mycal-cell__chips {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.mycal-chip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--brand-primary-tint);
+  color: var(--brand-primary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.mycal-chip__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mycal-chip__more {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding-left: 4px;
+}
+
+/* ---------- 셀 안의 건수 배지 (모바일) ---------- */
+.mycal-cell__count {
+  align-self: center;
+  margin-top: auto;
+  margin-bottom: auto;
+  min-width: 22px;
+  padding: 2px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--brand-primary);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+}
+
+/* ---------- 선택한 날짜의 일정 (PC: 오른쪽 패널 / 모바일: 팝업 안) ---------- */
+.mycal-detail {
+  /* 달력이 길어도 일정이 늘 눈에 보이게 따라다닌다. */
+  position: sticky;
+  top: 12px;
+  max-height: calc(100vh - 160px);
+  overflow-y: auto;
+  padding: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.mycal-detail__title {
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0 0 10px;
+}
+
+.mycal-detail__placeholder {
+  margin: 0;
+  padding: 20px 8px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.mycal-entry {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.mycal-entry__body {
+  min-width: 0;
+}
+
+.mycal-entry__company {
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  word-break: break-all;
+}
+
+.mycal-entry__link {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--brand-primary);
+  text-decoration: none;
+}
+
+.mycal-entry__link:hover {
+  text-decoration: underline;
+}
+
+.mycal-entry__memo {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  margin: 6px 0 0;
+  /* 사용자가 줄바꿈해서 적은 메모를 그대로 보여준다. */
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.mycal-entry__actions {
+  display: flex;
+  flex: 0 0 auto;
+}
+
+.mycal-entry__actions ion-button {
+  --padding-start: 6px;
+  --padding-end: 6px;
+  margin: 0;
+  height: 28px;
+  font-size: 12px;
+  text-transform: none;
+}
+
+ion-button.mycal-add-btn {
+  margin-top: 4px;
+  text-transform: none;
+  font-weight: 600;
+  --border-radius: var(--radius-pill);
+}
+
+/* ---------- 팝업 ---------- */
+.mycal-modal {
+  --border-radius: var(--radius-lg, 16px) var(--radius-lg, 16px) 0 0;
+  --background: var(--surface, #ffffff);
+}
+
+.mycal-modal__body {
+  padding: 16px 16px 28px;
+  overflow-y: auto;
+}
+
+.mycal-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.mycal-modal__header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.mycal-modal__header ion-button {
+  --color: var(--text-muted, #8b95a1);
+  margin: 0;
+}
+
+/* ---------- 등록·수정 폼 ---------- */
+.mycal-form-modal {
+  --background: var(--surface, #ffffff);
+  --width: min(480px, 92vw);
+  --height: auto;
+  --max-height: 90vh;
+  --border-radius: var(--radius-lg, 16px);
+}
+
+.mycal-form {
+  padding: 16px 16px 20px;
+  overflow-y: auto;
+}
+
+.mycal-field {
+  display: block;
+  margin-bottom: 14px;
+}
+
+.mycal-field__label {
+  display: block;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-strong);
+  margin-bottom: 6px;
+}
+
+.mycal-field__required {
+  font-style: normal;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--danger);
+  margin-left: 4px;
+}
+
+.mycal-field input,
+.mycal-field textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--text-strong);
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.mycal-field input:focus,
+.mycal-field textarea:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+}
+
+.mycal-field textarea {
+  resize: vertical;
+}
+
+.mycal-field__hint {
+  display: block;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.mycal-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.mycal-form__actions ion-button {
+  text-transform: none;
+  font-weight: 600;
+  --border-radius: var(--radius-pill);
+}
+
+/* ---------- 모바일 ---------- */
+@media (max-width: 768px) {
+  .mycal-grid {
+    gap: 4px;
+    padding: 8px;
+    border-radius: var(--radius-md);
+  }
+
+  .mycal-cell {
+    min-height: 52px;
+    padding: 4px;
+  }
+
+  .mycal-title {
+    font-size: 17px;
+    min-width: 105px;
+  }
+}

--- a/src/pages/MyCalendar.tsx
+++ b/src/pages/MyCalendar.tsx
@@ -1,0 +1,530 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  IonAlert,
+  IonButton,
+  IonContent,
+  IonIcon,
+  IonModal,
+  IonPage,
+  IonSpinner,
+} from '@ionic/react';
+import { closeOutline } from 'ionicons/icons';
+import { Helmet } from 'react-helmet';
+import CommonHeader from '../common/CommonHeader';
+import Sidebar from '../common/Sidebar';
+import LoginModal from '../components/LoginModal';
+import { useAuth } from '../common/AuthContextType';
+import useIsMobile from '../common/useIsMobile';
+import {
+  MyCalendarDay,
+  MyCalendarEntry,
+  MyCalendarMonth,
+  createMyCalendarEntry,
+  deleteMyCalendarEntry,
+  fetchMyCalendarMonth,
+  guessCompanyName,
+  updateMyCalendarEntry,
+} from '../common/myCalendarApi';
+import './MyCalendar.css';
+
+/** 달력은 월요일 시작. 서버의 dayOfWeek(1=월 ~ 7=일)와 인덱스를 맞춘다. */
+const WEEKDAYS = ['월', '화', '수', '목', '금', '토', '일'];
+
+/** PC 셀에 미리 보여줄 일정 수. 넘치면 "+N건" 으로 접는다. */
+const MAX_CHIPS_PER_CELL = 3;
+
+interface TargetMonth {
+  year: number;
+  month: number;
+}
+
+/** 작성 중인 일정. id 가 없으면 새 일정이다. */
+interface EntryForm {
+  id: number | null;
+  applyDate: string;
+  companyName: string;
+  url: string;
+  memo: string;
+}
+
+const pad = (value: number) => String(value).padStart(2, '0');
+
+const toDateKey = (year: number, month: number, day: number) => `${year}-${pad(month)}-${pad(day)}`;
+
+const thisMonth = (): TargetMonth => {
+  const now = new Date();
+  return { year: now.getFullYear(), month: now.getMonth() + 1 };
+};
+
+const todayKey = () => {
+  const now = new Date();
+  return toDateKey(now.getFullYear(), now.getMonth() + 1, now.getDate());
+};
+
+const shiftMonth = ({ year, month }: TargetMonth, delta: number): TargetMonth => {
+  // Date 가 연 넘어감(12월 → 1월)을 알아서 처리한다.
+  const shifted = new Date(year, month - 1 + delta, 1);
+  return { year: shifted.getFullYear(), month: shifted.getMonth() + 1 };
+};
+
+const formatDateLabel = (dateKey: string) => {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  const dayOfWeek = new Date(year, month - 1, day).getDay(); // 0=일
+  return `${month}월 ${day}일 (${WEEKDAYS[(dayOfWeek + 6) % 7]})`;
+};
+
+const emptyForm = (applyDate: string): EntryForm => ({
+  id: null,
+  applyDate,
+  companyName: '',
+  url: '',
+  memo: '',
+});
+
+const toForm = (entry: MyCalendarEntry): EntryForm => ({
+  id: entry.id,
+  applyDate: entry.applyDate,
+  companyName: entry.companyName,
+  url: entry.url ?? '',
+  memo: entry.memo ?? '',
+});
+
+const MyCalendar: React.FC = () => {
+  const history = useHistory();
+  const isMobile = useIsMobile();
+  const { isLoggedIn } = useAuth();
+
+  const [target, setTarget] = useState<TargetMonth>(thisMonth);
+  const [data, setData] = useState<MyCalendarMonth | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [selectedDate, setSelectedDate] = useState<string>(todayKey);
+  // 모바일은 2단 배치가 안 들어가 그날 일정을 팝업으로 띄운다. PC 는 오른쪽 패널에 항상 붙어 있다.
+  const [isDayOpen, setIsDayOpen] = useState<boolean>(false);
+
+  const [form, setForm] = useState<EntryForm | null>(null);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [guessing, setGuessing] = useState<boolean>(false);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState<boolean>(false);
+
+  const load = useCallback(async () => {
+    if (!isLoggedIn) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      setData(await fetchMyCalendarMonth(target.year, target.month));
+    } catch (error) {
+      setData(null);
+      setErrorMessage(error instanceof Error ? error.message : '캘린더를 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  }, [target, isLoggedIn]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const daysByDate = useMemo(() => {
+    const map = new Map<string, MyCalendarDay>();
+    data?.days.forEach((day) => map.set(day.date, day));
+    return map;
+  }, [data]);
+
+  const selectedDay = daysByDate.get(selectedDate);
+  const today = todayKey();
+
+  const handleDayClick = (dateKey: string) => {
+    setSelectedDate(dateKey);
+    if (isMobile) {
+      setIsDayOpen(true);
+    }
+  };
+
+  const goToMonth = (delta: number) => {
+    // 연속으로 빠르게 눌러도 한 달만 움직이지 않도록 이전 상태에서 계산한다.
+    setTarget((prev) => shiftMonth(prev, delta));
+  };
+
+  const handleLoginClick = () => {
+    if (isMobile) {
+      history.push('/login');
+    } else {
+      setShowLoginModal(true);
+    }
+  };
+
+  /**
+   * URL 을 다 적고 넘어갈 때 회사명을 대신 채워 준다.
+   * 이미 적어 둔 회사명은 건드리지 않는다 — 추측이 사용자가 쓴 값을 덮으면 안 된다.
+   */
+  const handleUrlBlur = async () => {
+    if (!form || !form.url.trim() || form.companyName.trim()) {
+      return;
+    }
+    setGuessing(true);
+    try {
+      const guessed = await guessCompanyName(form.url.trim());
+      // 추측하는 동안 사용자가 직접 적었을 수 있다. 그때는 사용자 값을 남긴다.
+      setForm((prev) =>
+        prev && guessed && !prev.companyName.trim() ? { ...prev, companyName: guessed } : prev,
+      );
+    } finally {
+      setGuessing(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!form) {
+      return;
+    }
+    if (!form.companyName.trim()) {
+      setErrorMessage('회사명을 입력해 주세요.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const input = {
+        applyDate: form.applyDate,
+        companyName: form.companyName.trim(),
+        url: form.url.trim(),
+        memo: form.memo.trim(),
+      };
+      if (form.id === null) {
+        await createMyCalendarEntry(input);
+      } else {
+        await updateMyCalendarEntry(form.id, input);
+      }
+      // 날짜를 옮겼을 수 있으니 저장한 날로 선택을 맞춘 뒤 다시 읽는다.
+      setSelectedDate(form.applyDate);
+      setForm(null);
+      await load();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '일정을 저장하지 못했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteMyCalendarEntry(id);
+      await load();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '일정을 삭제하지 못했습니다.');
+    }
+  };
+
+  const renderCells = (month: MyCalendarMonth) => {
+    // 1일이 월요일이 아니면 그만큼 앞을 비운다.
+    const blanks = Array.from({ length: month.firstDayOfWeek - 1 }, (_, index) => (
+      <div className="mycal-cell mycal-cell--blank" key={`blank-${index}`} />
+    ));
+
+    const cells = Array.from({ length: month.lengthOfMonth }, (_, index) => {
+      const dayNumber = index + 1;
+      const dateKey = toDateKey(month.year, month.month, dayNumber);
+      const day = daysByDate.get(dateKey);
+      const dayOfWeek = ((month.firstDayOfWeek - 1 + index) % 7) + 1;
+
+      const classNames = [
+        'mycal-cell',
+        dateKey === today ? 'mycal-cell--today' : '',
+        dateKey === selectedDate ? 'mycal-cell--selected' : '',
+        dayOfWeek === 6 ? 'mycal-cell--saturday' : '',
+        dayOfWeek === 7 ? 'mycal-cell--sunday' : '',
+      ].filter(Boolean).join(' ');
+
+      return (
+        <button
+          type="button"
+          className={classNames}
+          key={dateKey}
+          onClick={() => handleDayClick(dateKey)}
+          aria-label={
+            day
+              ? `${month.month}월 ${dayNumber}일 일정 ${day.count}건`
+              : `${month.month}월 ${dayNumber}일 일정 추가`
+          }
+        >
+          <span className="mycal-cell__day">{dayNumber}</span>
+          {day && (isMobile ? (
+            <span className="mycal-cell__count">{day.count}</span>
+          ) : (
+            <span className="mycal-cell__chips">
+              {day.entries.slice(0, MAX_CHIPS_PER_CELL).map((entry) => (
+                <span className="mycal-chip" key={entry.id}>
+                  <span className="mycal-chip__text">{entry.companyName}</span>
+                </span>
+              ))}
+              {day.count > MAX_CHIPS_PER_CELL && (
+                <span className="mycal-chip__more">+{day.count - MAX_CHIPS_PER_CELL}건</span>
+              )}
+            </span>
+          ))}
+        </button>
+      );
+    });
+
+    return [...blanks, ...cells];
+  };
+
+  const renderDayEntries = (day: MyCalendarDay | undefined) => (
+    <>
+      {(day?.entries ?? []).map((entry) => (
+        <div className="mycal-entry" key={entry.id}>
+          <div className="mycal-entry__body">
+            <h3 className="mycal-entry__company">{entry.companyName}</h3>
+            {entry.url && (
+              <a
+                className="mycal-entry__link"
+                href={entry.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                공고 열기
+              </a>
+            )}
+            {entry.memo && <p className="mycal-entry__memo">{entry.memo}</p>}
+          </div>
+          <div className="mycal-entry__actions">
+            <IonButton size="small" fill="clear" onClick={() => setForm(toForm(entry))}>
+              수정
+            </IonButton>
+            <IonButton size="small" fill="clear" color="danger" onClick={() => setDeleteTargetId(entry.id)}>
+              삭제
+            </IonButton>
+          </div>
+        </div>
+      ))}
+      {(day?.entries.length ?? 0) === 0 && (
+        <p className="mycal-detail__placeholder">
+          이 날에 적어 둔 일정이 없습니다.<br />
+          지원할 회사를 추가해 보세요.
+        </p>
+      )}
+      <IonButton
+        expand="block"
+        size="small"
+        className="mycal-add-btn"
+        onClick={() => setForm(emptyForm(selectedDate))}
+      >
+        + 일정 추가
+      </IonButton>
+    </>
+  );
+
+  const dayPanelTitle = `${formatDateLabel(selectedDate)} 일정 ${selectedDay?.count ?? 0}건`;
+
+  const renderCalendar = () => {
+    if (loading) {
+      return (
+        <div className="mycal-status">
+          <IonSpinner name="crescent" />
+        </div>
+      );
+    }
+    if (!data) {
+      return <div className="mycal-status">캘린더를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.</div>;
+    }
+    return (
+      <>
+        <p className="mycal-summary">
+          {data.month}월에 적어 둔 일정 <strong>{data.totalCount}건</strong>
+          <span className="mycal-summary__note">날짜를 누르면 그날 일정을 보고 추가할 수 있습니다.</span>
+        </p>
+
+        {/* PC: 왼쪽 달력 · 오른쪽 일정. 모바일: 달력만 두고 날짜를 누르면 팝업. */}
+        <div className="mycal-layout">
+          <div className="mycal-grid">
+            {WEEKDAYS.map((label, index) => (
+              <div
+                className={`mycal-weekday${index === 5 ? ' mycal-weekday--saturday' : ''}${index === 6 ? ' mycal-weekday--sunday' : ''}`}
+                key={label}
+              >
+                {label}
+              </div>
+            ))}
+            {renderCells(data)}
+          </div>
+
+          {!isMobile && (
+            <aside className="mycal-detail">
+              <h2 className="mycal-detail__title">{dayPanelTitle}</h2>
+              {renderDayEntries(selectedDay)}
+            </aside>
+          )}
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>나의 채용 캘린더 | 네카라쿠배당토야</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="내가 지원할 회사를 달력에 저장해 두는 나만의 채용 캘린더" />
+      </Helmet>
+      <CommonHeader />
+      <IonContent>
+        <div className="mypage-container">
+          <Sidebar activeTab="calendar" />
+          <div className="content">
+            <h2>나의 채용 캘린더</h2>
+
+            {!isLoggedIn ? (
+              // 개인 일정이라 로그인해야 볼 수 있다. 서버도 토큰 없이는 401 을 낸다.
+              <div className="mycal-login-gate">
+                <p>로그인하면 지원할 회사를 달력에 저장할 수 있습니다.</p>
+                <IonButton size="small" onClick={handleLoginClick}>로그인</IonButton>
+              </div>
+            ) : (
+              <>
+                <div className="mycal-toolbar">
+                  <IonButton fill="clear" className="mycal-nav-btn" onClick={() => goToMonth(-1)} aria-label="이전 달">
+                    &lsaquo;
+                  </IonButton>
+                  <h3 className="mycal-title">{target.year}년 {target.month}월</h3>
+                  <IonButton fill="clear" className="mycal-nav-btn" onClick={() => goToMonth(1)} aria-label="다음 달">
+                    &rsaquo;
+                  </IonButton>
+                  <IonButton size="small" fill="outline" className="mycal-today-btn" onClick={() => setTarget(thisMonth())}>
+                    이번 달
+                  </IonButton>
+                </div>
+
+                {renderCalendar()}
+              </>
+            )}
+          </div>
+        </div>
+      </IonContent>
+
+      {/* 모바일 전용 팝업. 날짜를 누르면 그날 일정이 시트로 올라온다. */}
+      <IonModal
+        isOpen={isMobile && isDayOpen}
+        onDidDismiss={() => setIsDayOpen(false)}
+        className="mycal-modal"
+        initialBreakpoint={0.75}
+        breakpoints={[0, 0.75, 1]}
+      >
+        <div className="mycal-modal__body">
+          <header className="mycal-modal__header">
+            <h2>{dayPanelTitle}</h2>
+            <IonButton fill="clear" size="small" aria-label="닫기" onClick={() => setIsDayOpen(false)}>
+              <IonIcon slot="icon-only" icon={closeOutline} />
+            </IonButton>
+          </header>
+          {renderDayEntries(selectedDay)}
+        </div>
+      </IonModal>
+
+      {/* 등록·수정 폼. 필수값은 회사명뿐이다. */}
+      <IonModal isOpen={form !== null} onDidDismiss={() => setForm(null)} className="mycal-form-modal">
+        {form && (
+          <div className="mycal-form">
+            <header className="mycal-modal__header">
+              <h2>{form.id === null ? '일정 추가' : '일정 수정'}</h2>
+              <IonButton fill="clear" size="small" aria-label="닫기" onClick={() => setForm(null)}>
+                <IonIcon slot="icon-only" icon={closeOutline} />
+              </IonButton>
+            </header>
+
+            <label className="mycal-field">
+              <span className="mycal-field__label">날짜</span>
+              <input
+                type="date"
+                value={form.applyDate}
+                onChange={(e) => setForm({ ...form, applyDate: e.target.value })}
+              />
+            </label>
+
+            <label className="mycal-field">
+              <span className="mycal-field__label">공고 URL</span>
+              <input
+                type="url"
+                inputMode="url"
+                value={form.url}
+                placeholder="https://careers.example.com/jobs/123"
+                onChange={(e) => setForm({ ...form, url: e.target.value })}
+                onBlur={handleUrlBlur}
+              />
+              <span className="mycal-field__hint">
+                {guessing ? '회사명을 찾는 중…' : '주소를 넣으면 회사명을 자동으로 채워 드립니다.'}
+              </span>
+            </label>
+
+            <label className="mycal-field">
+              <span className="mycal-field__label">
+                회사명 <em className="mycal-field__required">필수</em>
+              </span>
+              <input
+                type="text"
+                value={form.companyName}
+                maxLength={100}
+                placeholder="예) 카카오"
+                onChange={(e) => setForm({ ...form, companyName: e.target.value })}
+              />
+            </label>
+
+            <label className="mycal-field">
+              <span className="mycal-field__label">메모</span>
+              <textarea
+                rows={4}
+                value={form.memo}
+                maxLength={2000}
+                placeholder="예) 서류 마감 23:59, 포트폴리오 첨부 필요"
+                onChange={(e) => setForm({ ...form, memo: e.target.value })}
+              />
+            </label>
+
+            <div className="mycal-form__actions">
+              <IonButton fill="outline" onClick={() => setForm(null)}>취소</IonButton>
+              <IonButton onClick={handleSave} disabled={saving}>
+                {saving ? '저장 중…' : '저장'}
+              </IonButton>
+            </div>
+          </div>
+        )}
+      </IonModal>
+
+      <IonAlert
+        isOpen={deleteTargetId !== null}
+        onDidDismiss={() => setDeleteTargetId(null)}
+        header="일정 삭제"
+        message="이 일정을 삭제할까요?"
+        buttons={[
+          { text: '취소', role: 'cancel' },
+          {
+            text: '삭제',
+            role: 'destructive',
+            handler: () => {
+              if (deleteTargetId !== null) {
+                handleDelete(deleteTargetId);
+              }
+            },
+          },
+        ]}
+      />
+
+      <IonAlert
+        isOpen={!!errorMessage}
+        onDidDismiss={() => setErrorMessage('')}
+        header="알림"
+        message={errorMessage}
+        buttons={['확인']}
+      />
+
+      {/* 오버레이는 ion-header 안에 두면 Ionic 이 template 에 가둬 열리지 않는다. 헤더 밖에 둔다. */}
+      {!isMobile && <LoginModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />}
+    </IonPage>
+  );
+};
+
+export default MyCalendar;


### PR DESCRIPTION
마이페이지 사이드바에 "나의 채용 캘린더" 를 추가하고 `/mypage/calendar` 로 붙였다. 내가 지원할 회사를 달력에 저장해 두는 화면이다.

백엔드 PR(kingle1024/nklcbdty-service#214) 과 짝이라 **백엔드를 먼저 머지**해야 한다.

## 화면
- 마이페이지 사이드바 → 나의 채용 캘린더
- 월 이동(‹ › · 이번 달), 월요일 시작 달력
- 날짜를 누르면 그날 일정이 PC 는 오른쪽 패널, 모바일은 바텀 시트로 열린다
- 일정 추가 / 수정 / 삭제

공개 채용 캘린더와 달리 **일정이 없는 날도 누를 수 있다** — 빈 날에 새로 적는 것이 이 화면의 주된 사용법이라 비활성으로 두면 안 된다.

## 입력
| 항목 | 필수 | 비고 |
| --- | --- | --- |
| 날짜 | ○ | 누른 칸이 기본값 |
| 회사명 | ○ | 유일한 필수 입력값 |
| 공고 URL | | 넣으면 저장 후 "공고 열기" 링크 |
| 메모 | | 줄바꿈 그대로 보인다 |

URL 을 적고 넘어가면 서버에 회사명을 물어 대신 채운다(`careers.kakao.com` → 카카오, `recruit.navercorp.com` → 네이버). **이미 적어 둔 회사명은 덮지 않는다** — 추측이 사용자가 쓴 값을 이기면 안 되고, 추측하는 동안 사용자가 직접 적었을 때도 사용자 값을 남긴다.

## 로그인
개인 일정이라 로그인해야 쓸 수 있다(서버도 토큰 없이는 401). 비로그인 상태에서는 달력 대신 로그인 안내를 보여주고, PC 는 모달·모바일은 `/login` 으로 보낸다(헤더와 같은 규칙).

## 그 밖에
- 달력 격자·칩 모양은 `Calendar.css` 와 맞춰 공개 캘린더와 같은 달력으로 보이게 했다
- `Sidebar` 는 항목이 하나뿐이고 `window.location.href` 로 전체 새로고침을 하던 것을 목록 기반 + `history.push` 로 정리했다

## 확인
목 API 를 띄우고 `localhost:3100` 에서 확인했다 — 월 조회 · 날짜 선택 · 추가 · URL→회사명 자동 채움 · 수정(날짜를 옮기면 칩과 패널이 따라옴) · 로그인 게이트. 삭제 확인창은 브라우저 창이 화면에 안 떠 있어 `requestAnimationFrame` 이 돌지 않는 환경이라 Ionic 오버레이가 그려지지 않아 클릭까지는 못 해 봤다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a personal recruitment calendar accessible at `/mypage/calendar`.
  - View monthly application schedules, navigate between months, and select today.
  - Create, edit, and delete calendar entries with optional company-name detection from URLs.
  - Added responsive desktop and mobile calendar layouts with daily details.
  - Added login guidance for unauthenticated visitors.
  - Updated sidebar navigation with profile and calendar tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->