### PR TITLE
🐛 Fix: 일시적 오류에도 로그아웃되던 토큰 갱신 흐름 보강

### DIFF
--- a/src/common/UseTokenRefresh.ts
+++ b/src/common/UseTokenRefresh.ts
@@ -1,53 +1,77 @@
 // UseTokenRefresh.ts
-import { useState } from 'react';
+// 액세스 토큰(1시간)이 만료되면 리프레시 토큰(30일)으로 조용히 갱신해 로그인을 유지한다.
+// 로그아웃은 "리프레시 토큰이 정말 무효일 때"만 한다 — 일시적인 서버/네트워크 오류로
+// 로그아웃하면 사용자는 아무 이유 없이 로그인이 풀린 것처럼 보인다.
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { useAuth } from './AuthContextType';
 import API_URL from '../config';
-import { LikesResponse } from '../response/LikesResponse';
+
+type RefreshResult = 'ok' | 'invalid' | 'error';
+
+// 여러 컴포넌트/탭 내 요청이 동시에 401 을 받아도 갱신 요청은 한 번만 나가도록
+// 훅 인스턴스가 아니라 모듈 단위로 공유한다. (겹쳐 부르면 한쪽의 회전된 토큰이
+// 무효가 되어 로그아웃될 수 있다)
+let refreshPromise: Promise<RefreshResult> | null = null;
+
+const storedUserId = (): string | null => {
+  const raw = localStorage.getItem('authUser');
+  if (!raw) {
+    return null;
+  }
+  try {
+    return (JSON.parse(raw) as { userId?: string }).userId ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const requestTokenRefresh = async (): Promise<RefreshResult> => {
+  const refreshToken = localStorage.getItem('refreshToken');
+  const userId = storedUserId();
+  if (!refreshToken || !userId) {
+    return 'invalid';
+  }
+
+  try {
+    // 백엔드 RefreshRequest 는 { refreshToken, userVo: { userId } } 형태를 받는다.
+    const tokenResponse = await axios.post(`${API_URL}/api/auth/refresh`, {
+      refreshToken,
+      userVo: { userId }
+    }, {
+      headers: {
+        'Authorization': `Bearer ${refreshToken}`
+      }
+    });
+
+    localStorage.setItem('jwtToken', tokenResponse.data.accessToken);
+    localStorage.setItem('refreshToken', tokenResponse.data.refreshToken);
+    return 'ok';
+  } catch (refreshError) {
+    console.error('Error refreshing token:', refreshError);
+    if (axios.isAxiosError(refreshError) && refreshError.response?.status === 401) {
+      return 'invalid'; // 리프레시 토큰 만료/무효 — 다시 로그인해야 한다
+    }
+    return 'error'; // 서버 장애·네트워크 오류 — 로그인 상태는 유지한다
+  }
+};
+
+const refreshOnce = (): Promise<RefreshResult> => {
+  if (!refreshPromise) {
+    refreshPromise = requestTokenRefresh().finally(() => {
+      refreshPromise = null;
+    });
+  }
+  return refreshPromise;
+};
 
 const UseTokenRefresh = () => {
-  const { user, logout } = useAuth();
-  const [isRefreshing, setIsRefreshing] = useState(false);
-
-  const handleTokenRefresh = async () => {
-    const refreshToken = localStorage.getItem('refreshToken');
-    if (!refreshToken) {
-      console.log('refreshToken is null');
-      logout();
-      return;
-    }
-
-    if (!user?.userId) {
-      console.log('userId is null');
-      logout();
-      return;
-    }
-
-    try {
-      // 백엔드 RefreshRequest 는 { refreshToken, userVo: { userId } } 형태를 받는다.
-      const tokenResponse = await axios.post(`${API_URL}/api/auth/refresh`, {
-        refreshToken,
-        userVo: { userId: user.userId }
-      }, {
-        headers: {
-          'Authorization': `Bearer ${refreshToken}`
-        }
-      });
-
-      const newAccessToken = tokenResponse.data.accessToken;
-      const newRefreshToken = tokenResponse.data.refreshToken;
-      localStorage.setItem('jwtToken', newAccessToken);
-      localStorage.setItem('refreshToken', newRefreshToken);
-    } catch (refreshError) {
-      console.error('Error refreshing token:', refreshError);
-      logout();
-    }
-  };
+  const { logout } = useAuth();
 
   const fetchWithToken = async <T>(
     url: string,
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' = 'GET',
-    data?: any
+    data?: any,
+    isRetry = false
   ): Promise<T | null | undefined> => {
     const token = localStorage.getItem('jwtToken');
     if (!token) {
@@ -81,27 +105,29 @@ const UseTokenRefresh = () => {
         }
       } else if (lowerMethod === 'patch') {
         response = await axios.patch<T>(url, data, config); // PATCH는 url, data, config
-      } else if (lowerMethod === 'head') {
-        response = await axios.head<T>(url, config); // HEAD는 url과 config
       } else {
         console.error(`Unsupported HTTP method: ${method}`);
-        // 지원하지 않는 메소드인 경우 어떻게 처리할지 결정
-        // 현재 로직에 맞춰 undefined 반환
         return undefined;
       }
 
       return response.data;
     } catch (error: any) {
       console.error('Error fetching data:', error);
-      if (error.response && error.response.status === 401 && !isRefreshing) {
-        setIsRefreshing(true);
-        await handleTokenRefresh();
-        setIsRefreshing(false);
-        return fetchWithToken<T>(url, method, data);
-      } else {
-        logout();
+
+      if (error.response && error.response.status === 401 && !isRetry) {
+        const result = await refreshOnce();
+        if (result === 'ok') {
+          return fetchWithToken<T>(url, method, data, true);
+        }
+        if (result === 'invalid') {
+          logout();
+        }
         return undefined;
       }
+
+      // 401 이 아닌 오류(서버 500, 네트워크 단절 등)는 이 요청만 실패로 처리하고
+      // 로그인 상태는 건드리지 않는다.
+      return undefined;
     }
   };
 


### PR DESCRIPTION
## 문제

로그인이 자꾸 풀린다. 백엔드 회전 버그(kingle1024/nklcbdty-service 짝 PR에서 수정)에 더해, 프론트 갱신 흐름도 로그아웃을 남발했다.

## 수정 (`UseTokenRefresh.ts`)

- 서버 500·네트워크 단절 등 **401 이 아닌 오류에는 로그아웃하지 않는다** — 해당 요청만 실패 처리
- 갱신 실패도 **리프레시 토큰이 무효(401)일 때만** 로그아웃. 갱신 중 서버 장애면 로그인 유지
- 여러 컴포넌트가 동시에 401 을 받아도 **갱신 요청은 모듈 단위로 한 번만** 나간다 — 겹쳐 부르면 회전된 토큰이 무효가 되어 로그아웃될 수 있다
- 재시도는 1회로 제한(무한 루프 방지)

`tsc --noEmit` 통과. 공개 API(`fetchWithToken`)는 그대로라 호출부 변경 없음.

백엔드 PR이 먼저 배포되면 좋지만, 이 변경 단독으로도 기존 서버와 호환된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
