### PR TITLE
🚨 Fix: 모바일 나의 캘린더 — 날짜를 눌러도 일정·추가 버튼이 안 보이던 문제

### DIFF
--- a/src/pages/AdminSubscriptions.css
+++ b/src/pages/AdminSubscriptions.css
@@ -331,8 +331,10 @@
   font-size: 14px;
 }
 
-/* ===== 모달 ===== */
-ion-modal.show-modal {
+/* ===== 모달 =====
+   ion-modal.show-modal 로 두면 CRA 가 CSS 를 한 덩어리로 묶어 앱 안의 모든 모달
+   (나의 캘린더 날짜 팝업 등)까지 --height: auto 로 덮어썼다. 이 화면 모달에만 걸리도록 클래스를 붙인다. */
+ion-modal.admin-detail-modal {
   --width: 90vw;
   --max-width: 900px;
   --height: auto;

--- a/src/pages/AdminSubscriptions.tsx
+++ b/src/pages/AdminSubscriptions.tsx
@@ -530,7 +530,11 @@ const AdminSubscriptions: React.FC = () => {
         </div>
 
         {/* 편집 모달 */}
-        <IonModal isOpen={selectedUserId !== null} onDidDismiss={closeDetail}>
+        <IonModal
+          isOpen={selectedUserId !== null}
+          onDidDismiss={closeDetail}
+          className="admin-detail-modal"
+        >
           <div className="modal-container">
             <header className="modal-header">
               <div>

--- a/src/pages/MyCalendar.css
+++ b/src/pages/MyCalendar.css
@@ -335,6 +335,13 @@ ion-button.mycal-add-btn {
 .mycal-modal {
   --border-radius: var(--radius-lg, 16px) var(--radius-lg, 16px) 0 0;
   --background: var(--surface, #ffffff);
+  /*
+   * 시트 높이를 Ionic 기본값(:host(.modal-sheet)) 과 같은 값으로 다시 적어 둔다.
+   * CRA 는 모든 CSS 를 한 덩어리로 묶으므로 다른 화면의 ion-modal 규칙이 --height 를
+   * auto 로 덮어쓸 수 있고, 그러면 시트가 제목 줄만 남기고 접혀 일정·추가 버튼이 화면 밖으로 나간다.
+   */
+  --height: calc(100% - (var(--ion-safe-area-top, 0px) + 10px));
+  --max-height: none;
 }
 
 .mycal-modal ion-content.mycal-modal__content {


### PR DESCRIPTION
## 무엇이 문제였나

모바일에서 `나의 캘린더`의 날짜를 누르면 올라오는 시트가 **제목 줄만 남기고 접혀** 있었다.
일정이 0건인 날은 안내 문구와 `+ 일정 추가` 버튼이 통째로 화면 밖에 있어 일정을 새로 적을 방법이 없었다.

원인은 관리자 구독 화면의 CSS 한 줄이다.

```css
/* src/pages/AdminSubscriptions.css */
ion-modal.show-modal { --height: auto; --max-height: 80vh; ... }
```

- CRA 는 화면별 CSS 를 한 덩어리로 묶기 때문에 이 규칙이 **앱 안의 모든 모달**에 걸린다.
- 게다가 섀도 DOM 밖에서 온 규칙은 Ionic 의 `:host(.modal-sheet) { --height: calc(100% - …) }` 보다 우선한다.

그 결과 375x812 기준으로 시트가 이렇게 됐다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 시트 높이 | 58px (제목 줄) | 802px |
| ion-content 높이 | 0px | 744px |
| `+ 일정 추가` 위치 | y=916 (화면 밖) | y=358 |

일정이 있는 날도 같이 깨져 있었다 — 셀에 건수가 보여서 굳이 열어 볼 일이 없었을 뿐이다.

## 무엇을 고쳤나

- 관리자 상세 모달에 `admin-detail-modal` 클래스를 주고, 규칙을 그 모달로 좁혔다.
- 나의 캘린더 시트(`.mycal-modal`)에 Ionic 기본값과 같은 `--height` 를 다시 적어 뒀다.
  다른 화면에서 전역 `ion-modal` 규칙이 또 새더라도 시트가 접히지 않는다.

## 확인

목 API 를 띄우고 375x812(모바일)에서 확인했다.

- 0건인 날을 누르면 시트가 802px 로 열리고 `+ 일정 추가` 버튼이 보인다.
- 그 버튼 → 등록 폼 → 회사명만 적고 저장 → 요약이 `1건` → `2건` 으로 늘어난다.
- 일정이 있는 날도 목록과 버튼이 함께 보인다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the subscription edit modal styling to prevent unintended effects on other modals.
  * Updated the calendar modal to use the full available height, including device safe areas, for a more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->