### PR TITLE
✨ Feat: 모바일에서 "홈 화면에 앱 추가" 안내를 하단에 띄운다

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,18 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Ionic App" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <!--
+      크롬은 페이지가 뜨자마자 beforeinstallprompt 를 던지는데, 그때 React 는 아직 마운트되지 않았다.
+      여기서 먼저 받아 두고 이벤트로 알려 주면 하단 안내 배너(InstallPrompt)가 설치 프롬프트를 띄울 수 있다.
+    -->
+    <script>
+      window.addEventListener("beforeinstallprompt", function (event) {
+        // 기본 미니 인포바를 막고, 우리 배너의 버튼으로 띄운다.
+        event.preventDefault();
+        window.__deferredInstallPrompt = event;
+        window.dispatchEvent(new Event("deferredinstallpromptchange"));
+      });
+    </script>
     <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=b3851f460ed49a031b6c35cb808a1514&libraries=services"></script>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9366813459634197"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,7 +11,7 @@
       "src": "assets/icon/icon.png",
       "type": "image/png",
       "sizes": "512x512",
-      "purpose": "maskable"
+      "purpose": "any maskable"
     }
   ],
   "start_url": ".",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import AdminJobDeleteRequests from './pages/AdminJobDeleteRequests';
 import Board from './pages/Board';
 import BoardDetail from './pages/BoardDetail';
 import BoardWrite from './pages/BoardWrite';
+import InstallPrompt from './components/InstallPrompt';
 
 setupIonicReact();
 const queryClient = new QueryClient();
@@ -82,6 +83,9 @@ const App: React.FC = () => {
               />
             </IonRouterOutlet>
           </IonReactRouter>
+
+          {/* 모바일 웹에서만 뜨는 "홈 화면에 앱 추가" 안내. 화면 전환과 무관하게 하단에 고정된다. */}
+          <InstallPrompt />
         </AuthProvider>
       </QueryClientProvider>
     </IonApp>

--- a/src/common/useInstallPrompt.ts
+++ b/src/common/useInstallPrompt.ts
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/** 크롬(안드로이드)이 설치 가능하다고 알려줄 때 오는 이벤트. 표준 타입에 아직 없다. */
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+};
+
+/**
+ * 'native' = 브라우저 설치 프롬프트를 띄울 수 있다.
+ * 'ios' / 'android' = 설치 API 가 없어 손으로 하는 방법을 알려 준다.
+ */
+export type InstallMode = 'native' | 'ios' | 'android';
+
+const DISMISSED_KEY = 'installPromptDismissedAt';
+/** 닫기를 누르면 이 기간 동안 다시 띄우지 않는다. */
+const DISMISS_DURATION = 7 * 24 * 60 * 60 * 1000;
+/** useIsMobile 과 같은 기준(Ionic md breakpoint). */
+const MOBILE_MAX_WIDTH = 768;
+
+const getDeferredPrompt = () =>
+  (window as unknown as { __deferredInstallPrompt?: BeforeInstallPromptEvent })
+    .__deferredInstallPrompt;
+
+const clearDeferredPrompt = () => {
+  (window as unknown as { __deferredInstallPrompt?: BeforeInstallPromptEvent })
+    .__deferredInstallPrompt = undefined;
+};
+
+/** 이미 홈 화면에서(앱처럼) 실행 중이면 안내할 필요가 없다. */
+const isStandalone = () =>
+  window.matchMedia?.('(display-mode: standalone)').matches === true ||
+  (window.navigator as unknown as { standalone?: boolean }).standalone === true;
+
+const isIos = () => {
+  const ua = window.navigator.userAgent;
+  // iPadOS 13+ 는 데스크톱 사파리로 위장하므로 터치 지원까지 함께 본다.
+  return (
+    /iPhone|iPad|iPod/.test(ua) ||
+    (/Macintosh/.test(ua) && window.navigator.maxTouchPoints > 1)
+  );
+};
+
+const isMobile = () =>
+  /Android|iPhone|iPad|iPod|Mobile/i.test(window.navigator.userAgent) ||
+  (window.navigator.maxTouchPoints > 0 && window.innerWidth <= MOBILE_MAX_WIDTH);
+
+const isRecentlyDismissed = () => {
+  try {
+    const dismissedAt = Number(window.localStorage.getItem(DISMISSED_KEY));
+    return !!dismissedAt && Date.now() - dismissedAt < DISMISS_DURATION;
+  } catch {
+    // 사파리 시크릿 모드 등에서 localStorage 접근이 막힐 수 있다.
+    return false;
+  }
+};
+
+/**
+ * 모바일 웹에서 "홈 화면에 앱 추가" 안내를 띄울지 판단한다.
+ *
+ * - 안드로이드 크롬: beforeinstallprompt 가 오면 설치 프롬프트를 직접 띄운다.
+ * - iOS 사파리·프롬프트가 오지 않는 브라우저: 손으로 추가하는 방법을 알려 준다.
+ */
+const useInstallPrompt = () => {
+  const [mode, setMode] = useState<InstallMode | null>(null);
+  const [dismissed, setDismissed] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!isMobile() || isStandalone() || isRecentlyDismissed()) {
+      return;
+    }
+
+    const syncMode = () => {
+      if (getDeferredPrompt()) {
+        setMode('native');
+      } else {
+        setMode(isIos() ? 'ios' : 'android');
+      }
+    };
+
+    syncMode();
+
+    const handleInstalled = () => {
+      clearDeferredPrompt();
+      setMode(null);
+    };
+
+    // index.html 이 먼저 받아 뒀을 수도, 마운트 이후에 올 수도 있다.
+    window.addEventListener('deferredinstallpromptchange', syncMode);
+    window.addEventListener('appinstalled', handleInstalled);
+
+    return () => {
+      window.removeEventListener('deferredinstallpromptchange', syncMode);
+      window.removeEventListener('appinstalled', handleInstalled);
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    try {
+      window.localStorage.setItem(DISMISSED_KEY, String(Date.now()));
+    } catch {
+      // 저장에 실패해도 이번 방문에서는 닫아 둔다.
+    }
+    setDismissed(true);
+  }, []);
+
+  /** 브라우저 설치 프롬프트를 띄운다. 거절하면 배너는 닫아 둔다. */
+  const install = useCallback(async () => {
+    const deferredPrompt = getDeferredPrompt();
+    if (!deferredPrompt) {
+      return;
+    }
+    await deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    clearDeferredPrompt();
+
+    if (outcome === 'accepted') {
+      setMode(null);
+    } else {
+      dismiss();
+    }
+  }, [dismiss]);
+
+  return { visible: mode !== null && !dismissed, mode, install, dismiss };
+};
+
+export default useInstallPrompt;

--- a/src/components/InstallPrompt.css
+++ b/src/components/InstallPrompt.css
@@ -1,0 +1,102 @@
+/*
+ * 홈 화면 추가 안내 배너 — 모바일 화면 아래에 떠 있는다.
+ * 표시 여부는 useInstallPrompt 가 정하고, 여기서는 모양만 잡는다.
+ */
+.install-prompt {
+  position: fixed;
+  left: 12px;
+  right: 12px;
+  /* 아이폰 홈 인디케이터에 가리지 않게 여백을 둔다. */
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  padding: 12px;
+  border: 1px solid var(--border, #e5e8eb);
+  border-radius: var(--radius-lg, 16px);
+  background: var(--surface, #fff);
+  box-shadow: var(--shadow-card-hover, 0 6px 20px rgba(25, 31, 40, 0.1));
+  /* Ionic 모달(20000)보다는 아래, 본문보다는 위. */
+  z-index: 1000;
+  animation: install-prompt-in 240ms ease-out;
+}
+
+@keyframes install-prompt-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.install-prompt__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.install-prompt__icon {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm, 8px);
+  background: var(--surface-field, #f2f4f6);
+  object-fit: contain;
+}
+
+.install-prompt__text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.install-prompt__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-strong, #191f28);
+}
+
+.install-prompt__desc {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary, #4e5968);
+  margin-top: 2px;
+}
+
+ion-button.install-prompt__cta {
+  flex: 0 0 auto;
+  margin: 0;
+  height: 34px;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: none;
+  --border-radius: var(--radius-pill, 9999px);
+  --padding-start: 14px;
+  --padding-end: 14px;
+}
+
+ion-button.install-prompt__close {
+  flex: 0 0 auto;
+  margin: 0;
+  height: 34px;
+  --color: var(--text-muted, #8b95a1);
+  --padding-start: 4px;
+  --padding-end: 4px;
+}
+
+.install-prompt__steps {
+  margin: 10px 0 0;
+  padding: 10px 0 0 20px;
+  border-top: 1px solid var(--divider, #f2f4f6);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--text-secondary, #4e5968);
+}
+
+/* PC 폭에서는 애초에 렌더링하지 않지만, 창을 넓혀 둔 경우까지 막는다. */
+@media (min-width: 769px) {
+  .install-prompt {
+    display: none;
+  }
+}

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { IonButton, IonIcon } from '@ionic/react';
+import { closeOutline } from 'ionicons/icons';
+import useInstallPrompt from '../common/useInstallPrompt';
+import './InstallPrompt.css';
+
+/** 브라우저마다 "홈 화면에 추가"까지 가는 길이 달라 각각 적어 준다. */
+const STEPS: Record<'ios' | 'android', string[]> = {
+  ios: [
+    '사파리 하단의 공유 버튼(⬆)을 누르세요.',
+    "목록에서 '홈 화면에 추가'를 고르세요.",
+    "오른쪽 위 '추가'를 누르면 끝입니다.",
+  ],
+  android: [
+    '브라우저 오른쪽 위 ⋮ 를 누르세요.',
+    "'앱 설치' 또는 '홈 화면에 추가'를 고르세요.",
+    "'설치'를 누르면 끝입니다.",
+  ],
+};
+
+/**
+ * 모바일 웹에서 홈 화면에 추가하도록 안내하는 하단 배너.
+ * 이미 설치했거나 PC 로 보는 중이면 아무것도 그리지 않는다.
+ */
+const InstallPrompt: React.FC = () => {
+  const { visible, mode, install, dismiss } = useInstallPrompt();
+  const [showSteps, setShowSteps] = useState<boolean>(false);
+
+  if (!visible) {
+    return null;
+  }
+
+  // 손으로 추가하는 순서. 설치 프롬프트가 오는 브라우저에서는 필요 없다.
+  const steps = mode === 'ios' || mode === 'android' ? STEPS[mode] : null;
+
+  const handleClick = () => {
+    if (mode === 'native') {
+      install();
+    } else {
+      // 설치 API 가 없는 브라우저다. 손으로 하는 방법을 펼쳐 준다.
+      setShowSteps((prev) => !prev);
+    }
+  };
+
+  return (
+    <div className="install-prompt" role="complementary" aria-label="홈 화면에 앱 추가 안내">
+      <div className="install-prompt__row">
+        <img className="install-prompt__icon" src="/assets/icon/icon.png" alt="" />
+
+        <div className="install-prompt__text">
+          <strong className="install-prompt__title">홈 화면에 앱 추가</strong>
+          <span className="install-prompt__desc">
+            추가해 두면 앱처럼 바로 열어 공고를 볼 수 있어요.
+          </span>
+        </div>
+
+        <IonButton size="small" className="install-prompt__cta" onClick={handleClick}>
+          {mode === 'native' ? '추가' : showSteps ? '닫기' : '방법'}
+        </IonButton>
+
+        <IonButton
+          fill="clear"
+          size="small"
+          className="install-prompt__close"
+          aria-label="안내 닫기"
+          onClick={dismiss}
+        >
+          <IonIcon slot="icon-only" icon={closeOutline} />
+        </IonButton>
+      </div>
+
+      {steps && showSteps && (
+        <ol className="install-prompt__steps">
+          {steps.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+};
+
+export default InstallPrompt;


### PR DESCRIPTION
## 무엇을 했나

`football-club-teal.vercel.app` 처럼, **모바일 웹으로 들어온 방문자에게만** 홈 화면 추가를 권하는 배너를 화면 아래에 띄운다.

- **안드로이드 크롬** — `beforeinstallprompt` 를 받아 두고 `추가` 버튼으로 브라우저 설치 프롬프트를 띄운다.
  이 이벤트는 React 가 마운트되기 전에 오는 경우가 많아 `public/index.html` 에서 먼저 잡아 둔다.
- **iOS 사파리 / 프롬프트가 오지 않는 브라우저** — 설치 API 가 없으므로 `방법` 을 누르면 `공유 → 홈 화면에 추가` 순서를 펼쳐 준다.
- 이미 홈 화면에서 실행 중(`display-mode: standalone`)이거나 PC 폭이면 아무것도 렌더링하지 않는다.
- `X` 로 닫으면 **7일 동안** 다시 뜨지 않는다 (localStorage).

`manifest.json` 의 512px 아이콘 purpose 를 `maskable` → `any maskable` 로 바꿨다.
maskable 만 있으면 크롬이 설치 가능으로 보지 않아 프롬프트가 아예 오지 않는다.

## 파일

| 파일 | 역할 |
|---|---|
| `src/common/useInstallPrompt.ts` | 띄울지 여부와 모드(native/ios/android) 판단, 설치·닫기 |
| `src/components/InstallPrompt.tsx` / `.css` | 하단 배너 UI |
| `src/App.tsx` | 라우터 밖에 한 번만 올려 모든 화면에서 하단 고정 |
| `public/index.html` | React 보다 먼저 오는 `beforeinstallprompt` 캡처 |

## 확인

| 상황 | 결과 |
|---|---|
| 375x812 + 설치 프롬프트 있음 | 배너 노출, `추가` → `prompt()` 호출 후 배너 사라짐 |
| 390x844 + iOS UA | `방법` → 3단계 안내 펼침 |
| 닫기 → 새로 고침 | 다시 뜨지 않음 |
| 1280x900 (PC) | 렌더링되지 않음 |

<details>
<summary>iOS 안내 펼친 모습</summary>

배너가 하단에 뜨고, `방법` 을 누르면 `1. 공유 버튼 → 2. 홈 화면에 추가 → 3. 추가` 순서가 펼쳐진다.

</details>

## 참고

안드로이드에서 네이티브 설치 프롬프트가 뜨려면 브라우저가 이 사이트를 "설치 가능"으로 판정해야 한다.
현재 이 앱은 서비스 워커를 등록하지 않는다(`serviceWorkerRegistration.unregister()`).
크롬 버전에 따라 서비스 워커를 요구할 수 있고, 그런 경우엔 프롬프트가 오지 않으므로 배너가 자동으로 `방법`(수동 안내) 모드로 떨어진다 — 어느 쪽이든 안내 자체는 항상 동작한다.
캐싱 부작용 없이 프롬프트까지 열고 싶으면, 통과만 시키는 최소 서비스 워커를 따로 올리는 방법이 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)