### PR TITLE
🚨 Fix: 삼성 인터넷에서는 홈 화면 추가 안내를 띄우지 않는다 — Play 프로텍트가 막는 길이라

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,11 @@
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-title" content="Ionic App" />
+    <!-- 홈 화면 아이콘 아래에 적히는 이름. 손대지 않으면 "Ionic App" 이 그대로 박힌다. -->
+    <meta name="apple-mobile-web-app-title" content="네카라쿠배당토야" />
+    <!-- iOS 는 매니페스트가 아니라 이 링크로 홈 화면 아이콘을 고른다.
+         없으면 아이콘 자리에 화면을 찍은 그림이 들어간다. -->
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/images/og.png" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <!--
       크롬은 페이지가 뜨자마자 beforeinstallprompt 를 던지는데, 그때 React 는 아직 마운트되지 않았다.

--- a/src/common/useInstallPrompt.ts
+++ b/src/common/useInstallPrompt.ts
@@ -45,6 +45,26 @@ const isMobile = () =>
   /Android|iPhone|iPad|iPod|Mobile/i.test(window.navigator.userAgent) ||
   (window.navigator.maxTouchPoints > 0 && window.innerWidth <= MOBILE_MAX_WIDTH);
 
+/**
+ * 삼성 인터넷인가. **여기서는 설치를 권하지 않는다.**
+ *
+ * 삼성 인터넷은 PWA 를 설치할 때 WebAPK 를 기기 안에서 직접 만들어 서명한다
+ * (크롬은 구글 서버가 만들어 서명한 것을 받아 온다). 그렇게 만든 APK 의
+ * targetSdkVersion 이 낮아서, 안드로이드 14 이상은 설치를 막고 겁주는 창을 띄운다 —
+ * "안전하지 않은 앱 차단됨 / 이 앱은 Android 이전 버전에 맞게 개발되었으며 최신
+ * 개인 정보 보호 기능을 포함하지 않습니다" (2026-08-21 갤럭시에서 확인).
+ *
+ * 우리가 고칠 수 있는 값이 아니다 — targetSdkVersion 은 브라우저가 만드는 APK 안에
+ * 있고 매니페스트에는 없다. 안내 문구를 어떻게 고쳐도 그 창은 그대로 뜬다. 그래서
+ * 이 브라우저에서는 배너를 아예 띄우지 않는다. 겁주는 창으로 끝나는 길을 권하는
+ * 것보다 없는 편이 낫다.
+ *
+ * 브라우저가 스스로 띄우는 설치 안내는 index.html 의 beforeinstallprompt 처리에서
+ * 이미 preventDefault() 로 막혀 있어 여기서 더 할 일이 없다. 그래도 홈 화면에 두고
+ * 싶은 사람은 브라우저 메뉴로 직접 추가할 수 있다 — 그 길까지 막을 수는 없다.
+ */
+const isSamsungInternet = () => /SamsungBrowser/.test(window.navigator.userAgent);
+
 const isRecentlyDismissed = () => {
   try {
     const dismissedAt = Number(window.localStorage.getItem(DISMISSED_KEY));
@@ -60,13 +80,14 @@ const isRecentlyDismissed = () => {
  *
  * - 안드로이드 크롬: beforeinstallprompt 가 오면 설치 프롬프트를 직접 띄운다.
  * - iOS 사파리·프롬프트가 오지 않는 브라우저: 손으로 추가하는 방법을 알려 준다.
+ * - 삼성 인터넷: 아무것도 띄우지 않는다. 이유는 isSamsungInternet() 에 적어 두었다.
  */
 const useInstallPrompt = () => {
   const [mode, setMode] = useState<InstallMode | null>(null);
   const [dismissed, setDismissed] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!isMobile() || isStandalone() || isRecentlyDismissed()) {
+    if (!isMobile() || isStandalone() || isRecentlyDismissed() || isSamsungInternet()) {
       return;
     }
 


### PR DESCRIPTION
갤럭시에서 하단 배너의 **[추가]** 를 누르면 설치가 되지 않고 이 창이 뜬다.

> **안전하지 않은 앱 차단됨**
> 이 앱은 Android 이전 버전에 맞게 개발되었으며 최신 개인 정보 보호 기능을 포함하지 않습니다.

## 왜 그런가

삼성 인터넷은 PWA 를 설치할 때 **WebAPK 를 기기 안에서 직접 만들어 서명한다.** 크롬은
구글 서버가 만들어 서명한 것을 받아 오는데, 삼성이 만든 APK 의 `targetSdkVersion` 이
낮아서 안드로이드 14 이상이 설치를 막고 저 창을 띄운다.

**우리가 고칠 수 있는 값이 아니다.** `targetSdkVersion` 은 브라우저가 만드는 APK 안에
있고 웹 매니페스트에는 없다. 안내 문구를 어떻게 고쳐도 그 창은 그대로 뜬다.

## 그래서

삼성 인터넷(`SamsungBrowser`)에서는 **배너를 아예 띄우지 않는다** (`useInstallPrompt`).
겁주는 창으로 끝나는 길을 권하는 것보다 없는 편이 낫다. 브라우저가 스스로 띄우는 설치
안내는 `index.html` 의 `beforeinstallprompt` 처리에서 이미 `preventDefault()` 로 막혀
있어 그대로 둔다. 그래도 홈 화면에 두고 싶은 사람은 브라우저 메뉴로 직접 추가할 수 있다.

바뀌지 않는 것: 크롬 계열의 [추가] 버튼, iOS 사파리의 [방법] 안내.

## 같이 고친 것 — iOS 로 추가했을 때의 아이콘·이름

이 배너가 iOS 사용자에게 "홈 화면에 추가" 를 권하는데, 정작 추가하면 이렇게 됐다.

- `apple-mobile-web-app-title` 이 **"Ionic App"** — 홈 화면 아이콘 아래에 그 이름이 박힌다.
- `apple-touch-icon` 이 없음 — iOS 는 매니페스트를 보지 않아서, 없으면 아이콘 자리에
  화면을 찍은 그림이 들어간다. `images/og.png`(파비콘과 같은 그림)를 걸었다.

## 확인

운영 빌드를 정적 서버로 띄우고 헤드리스 크롬 390px 에서 UA 만 바꿔 봤다.

| UA | 결과 |
| --- | --- |
| `SamsungBrowser/25.0` | 20초를 기다려도 배너 없음 |
| 안드로이드 크롬 | 배너 + [추가] 그대로 |
| iOS 사파리 | 배너 + [방법] 그대로 |
| 데스크톱 1280px | 배너 없음 (그대로) |

닫기를 누르면 사라지고 새로고침 뒤에도 조용하다. `tsc --noEmit` · `eslint` · 운영 빌드 통과.

## 남겨 둔 것

매니페스트의 앱 아이콘이 아직 **Ionic 기본 로고**(`assets/icon/icon.png`)다. 안드로이드로
설치하면 홈 화면에 그 로고가 올라간다. 파비콘·OG 와 같은 `images/og.png` 로 바꾸는 게
맞아 보이는데, 브랜딩 결정이라 이 PR 에서는 손대지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the app name displayed when added to an iOS home screen.
  - Added a custom iOS home-screen icon.

- **Bug Fixes**
  - Improved installation prompt behavior by preventing it from appearing in Samsung Internet, where installation support is limited.
  - Refined mobile browser eligibility checks for a more consistent install experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->