### PR TITLE
✨ Feat: 나의 캘린더에 상시채용 목록과 완료 버튼

### DIFF
--- a/src/common/myCalendarApi.ts
+++ b/src/common/myCalendarApi.ts
@@ -5,11 +5,16 @@ import API_URL from '../config';
 
 export interface MyCalendarEntry {
   id: number;
-  /** yyyy-MM-dd */
-  applyDate: string;
+  /** yyyy-MM-dd. 상시채용이면 null. */
+  applyDate: string | null;
+  /** 마감일 없는 상시채용인지. 참이면 달력 칸이 아니라 상시채용 목록에 들어간다. */
+  ongoing: boolean;
   companyName: string;
   url: string | null;
   memo: string | null;
+  /** 지원을 마쳤다고 손으로 표시했는지 */
+  completed: boolean;
+  completedAt: string | null;
 }
 
 export interface MyCalendarDay {
@@ -24,12 +29,19 @@ export interface MyCalendarMonth {
   month: number;
   firstDayOfWeek: number;
   lengthOfMonth: number;
+  /** 그 달에 적어 둔 일정 건수. 상시채용은 특정 달의 것이 아니라 여기에 안 들어간다. */
   totalCount: number;
   days: MyCalendarDay[];
+  /** 마감일 없는 상시채용. 어느 달을 조회해도 같은 목록이 온다. */
+  ongoingEntries: MyCalendarEntry[];
+  ongoingCount: number;
 }
 
 export interface MyCalendarEntryInput {
+  /** ongoing 이 참이면 서버가 무시한다. */
   applyDate: string;
+  /** 상시채용으로 저장할지. 참이면 날짜 없이 저장된다. */
+  ongoing: boolean;
   companyName: string;
   url: string;
   memo: string;
@@ -91,6 +103,30 @@ export const updateMyCalendarEntry = async (
     return res.data;
   } catch (error) {
     throw new Error(messageOf(error, '일정을 수정하지 못했습니다.'));
+  }
+};
+
+/**
+ * 완료 표시를 켜고 끈다. 상시채용은 마감일이 없어 목록에서 저절로 내려가지 않으므로 필요하다.
+ *
+ * 켤지 끌지를 그대로 보내므로 같은 요청이 두 번 가도 결과가 같다. PATCH 가 어울리지만 PUT 이다 —
+ * 서버 CORS 가 PATCH 를 허용하지 않아서 PATCH 로 보내면 preflight 에서 막힌다.
+ */
+export const setMyCalendarEntryCompleted = async (
+  id: number,
+  completed: boolean,
+): Promise<MyCalendarEntry> => {
+  try {
+    const res = await axios.put<MyCalendarEntry>(
+      `${API_URL}/api/my-calendar/entries/${id}/complete`,
+      { completed },
+      { headers: authHeaders() },
+    );
+    return res.data;
+  } catch (error) {
+    throw new Error(
+      messageOf(error, completed ? '완료로 표시하지 못했습니다.' : '완료를 되돌리지 못했습니다.'),
+    );
   }
 };
 

--- a/src/pages/MyCalendar.css
+++ b/src/pages/MyCalendar.css
@@ -216,6 +216,13 @@
   white-space: nowrap;
 }
 
+/* 완료한 일정은 칸에서 눈에 덜 띄게 둔다 — 지운 게 아니라 끝낸 것이다. */
+.mycal-chip--done {
+  background: var(--surface-field);
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+
 .mycal-chip__more {
   font-size: 11px;
   font-weight: 600;
@@ -289,6 +296,37 @@
   word-break: break-all;
 }
 
+/* 완료한 일정. 지운 게 아니라 끝낸 것이라 남겨 두고 흐리게만 보여준다. */
+.mycal-entry--done {
+  background: var(--surface-bg);
+  border-color: var(--border);
+}
+
+.mycal-entry--done .mycal-entry__company {
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+
+.mycal-entry--done .mycal-entry__memo {
+  color: var(--text-muted);
+}
+
+.mycal-entry__badge {
+  /*
+   * inline-block 이어야 한다. 회사명에 걸린 취소선은 자식에게 그대로 그려지고
+   * text-decoration: none 으로는 지워지지 않는다 — inline-block 이 그 전파를 끊는다.
+   */
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--success-tint);
+  color: var(--success);
+  font-size: 11px;
+  font-weight: 700;
+  vertical-align: middle;
+}
+
 .mycal-entry__link {
   font-size: 13px;
   font-weight: 600;
@@ -322,6 +360,33 @@
   height: 28px;
   font-size: 12px;
   text-transform: none;
+}
+
+/* ---------- 상시채용 (마감일 없어 달력 칸에 못 찍는 일정) ---------- */
+.mycal-ongoing {
+  margin-top: 20px;
+  padding: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.mycal-ongoing__title {
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0 0 10px;
+}
+
+.mycal-ongoing__title strong {
+  color: var(--brand-primary);
+}
+
+.mycal-ongoing__note {
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-top: 3px;
 }
 
 ion-button.mycal-add-btn {
@@ -442,6 +507,34 @@ ion-button.mycal-add-btn {
   resize: vertical;
 }
 
+/* 상시채용 체크박스. 다른 입력칸과 달리 라벨을 오른쪽에 붙인다. */
+.mycal-field--check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mycal-field--check input[type='checkbox'] {
+  /* .mycal-field input 의 width:100% 를 되돌린다. */
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  padding: 0;
+  margin: 0;
+  accent-color: var(--brand-primary);
+}
+
+.mycal-field--check .mycal-field__label {
+  margin-bottom: 0;
+}
+
+/* 상시채용을 켜면 날짜를 못 고른다는 걸 눈으로 알 수 있게 한다. */
+.mycal-field input:disabled {
+  background: var(--surface-field);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
 .mycal-field__hint {
   display: block;
   font-size: 12px;
@@ -531,6 +624,20 @@ ion-button.mycal-add-btn {
   /* 팝업 안에서 수정·삭제를 누르는 손가락이 미끄러지지 않게 키운다. */
   .mycal-entry {
     padding: 12px;
+    /* 완료가 생겨 버튼이 세 개다. 좁으면 회사명을 밀어내지 말고 아래 줄로 접는다. */
+    flex-wrap: wrap;
+  }
+
+  /*
+   * min-width:0 만 두면 회사명이 0 까지 줄어들어 버튼이 절대 안 접힌다.
+   * 60% 를 요구해 두면 버튼이 안 들어갈 때만 다음 줄로 내려간다.
+   */
+  .mycal-entry__body {
+    flex: 1 1 60%;
+  }
+
+  .mycal-entry__actions {
+    margin-left: auto;
   }
 
   .mycal-entry__actions ion-button {

--- a/src/pages/MyCalendar.tsx
+++ b/src/pages/MyCalendar.tsx
@@ -24,6 +24,7 @@ import {
   deleteMyCalendarEntry,
   fetchMyCalendarMonth,
   guessCompanyName,
+  setMyCalendarEntryCompleted,
   updateMyCalendarEntry,
 } from '../common/myCalendarApi';
 import './MyCalendar.css';
@@ -42,7 +43,10 @@ interface TargetMonth {
 /** 작성 중인 일정. id 가 없으면 새 일정이다. */
 interface EntryForm {
   id: number | null;
+  /** ongoing 이 참이면 저장할 때 버려진다. 체크를 풀었을 때 되살리려고 그대로 들고 있는다. */
   applyDate: string;
+  /** 마감일 없는 상시채용으로 저장할지 */
+  ongoing: boolean;
   companyName: string;
   url: string;
   memo: string;
@@ -74,9 +78,10 @@ const formatDateLabel = (dateKey: string) => {
   return `${month}월 ${day}일 (${WEEKDAYS[(dayOfWeek + 6) % 7]})`;
 };
 
-const emptyForm = (applyDate: string): EntryForm => ({
+const emptyForm = (applyDate: string, ongoing = false): EntryForm => ({
   id: null,
   applyDate,
+  ongoing,
   companyName: '',
   url: '',
   memo: '',
@@ -84,7 +89,9 @@ const emptyForm = (applyDate: string): EntryForm => ({
 
 const toForm = (entry: MyCalendarEntry): EntryForm => ({
   id: entry.id,
-  applyDate: entry.applyDate,
+  // 상시채용은 날짜가 없다. 체크를 풀면 고를 날짜가 있어야 하니 오늘로 채워 둔다.
+  applyDate: entry.applyDate ?? todayKey(),
+  ongoing: entry.ongoing,
   companyName: entry.companyName,
   url: entry.url ?? '',
   memo: entry.memo ?? '',
@@ -107,6 +114,8 @@ const MyCalendar: React.FC = () => {
   const [saving, setSaving] = useState<boolean>(false);
   const [guessing, setGuessing] = useState<boolean>(false);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  // 완료를 누른 일정. 응답을 기다리는 동안 그 버튼만 잠근다.
+  const [togglingId, setTogglingId] = useState<number | null>(null);
   const [showLoginModal, setShowLoginModal] = useState<boolean>(false);
 
   const load = useCallback(async () => {
@@ -190,6 +199,7 @@ const MyCalendar: React.FC = () => {
     try {
       const input = {
         applyDate: form.applyDate,
+        ongoing: form.ongoing,
         companyName: form.companyName.trim(),
         url: form.url.trim(),
         memo: form.memo.trim(),
@@ -200,13 +210,32 @@ const MyCalendar: React.FC = () => {
         await updateMyCalendarEntry(form.id, input);
       }
       // 날짜를 옮겼을 수 있으니 저장한 날로 선택을 맞춘 뒤 다시 읽는다.
-      setSelectedDate(form.applyDate);
+      // 상시채용은 어느 날짜에도 안 붙으므로 보고 있던 날을 그대로 둔다.
+      if (!form.ongoing) {
+        setSelectedDate(form.applyDate);
+      }
       setForm(null);
       await load();
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : '일정을 저장하지 못했습니다.');
     } finally {
       setSaving(false);
+    }
+  };
+
+  /**
+   * 완료 표시를 켜고 끈다. 다시 읽는 동안 버튼이 두 번 눌리면 요청이 두 번 가지만,
+   * 서버가 켤지 끌지를 그대로 받으므로 결과는 같다.
+   */
+  const handleToggleCompleted = async (entry: MyCalendarEntry) => {
+    setTogglingId(entry.id);
+    try {
+      await setMyCalendarEntryCompleted(entry.id, !entry.completed);
+      await load();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '완료 표시를 바꾸지 못했습니다.');
+    } finally {
+      setTogglingId(null);
     }
   };
 
@@ -257,8 +286,13 @@ const MyCalendar: React.FC = () => {
           ) : (
             <span className="mycal-cell__chips">
               {day.entries.slice(0, MAX_CHIPS_PER_CELL).map((entry) => (
-                <span className="mycal-chip" key={entry.id}>
-                  <span className="mycal-chip__text">{entry.companyName}</span>
+                <span
+                  className={`mycal-chip${entry.completed ? ' mycal-chip--done' : ''}`}
+                  key={entry.id}
+                >
+                  <span className="mycal-chip__text">
+                    {entry.completed ? '✓ ' : ''}{entry.companyName}
+                  </span>
                 </span>
               ))}
               {day.count > MAX_CHIPS_PER_CELL && (
@@ -273,34 +307,49 @@ const MyCalendar: React.FC = () => {
     return [...blanks, ...cells];
   };
 
+  /** 일정 한 건. 날짜 있는 일정과 상시채용이 같은 모양이라 한 곳에서 그린다. */
+  const renderEntry = (entry: MyCalendarEntry) => (
+    <div className={`mycal-entry${entry.completed ? ' mycal-entry--done' : ''}`} key={entry.id}>
+      <div className="mycal-entry__body">
+        <h3 className="mycal-entry__company">
+          {entry.companyName}
+          {entry.completed && <span className="mycal-entry__badge">완료</span>}
+        </h3>
+        {entry.url && (
+          <a
+            className="mycal-entry__link"
+            href={entry.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            공고 열기
+          </a>
+        )}
+        {entry.memo && <p className="mycal-entry__memo">{entry.memo}</p>}
+      </div>
+      <div className="mycal-entry__actions">
+        <IonButton
+          size="small"
+          fill="clear"
+          color={entry.completed ? 'medium' : 'success'}
+          disabled={togglingId === entry.id}
+          onClick={() => handleToggleCompleted(entry)}
+        >
+          {entry.completed ? '되돌리기' : '완료'}
+        </IonButton>
+        <IonButton size="small" fill="clear" onClick={() => setForm(toForm(entry))}>
+          수정
+        </IonButton>
+        <IonButton size="small" fill="clear" color="danger" onClick={() => setDeleteTargetId(entry.id)}>
+          삭제
+        </IonButton>
+      </div>
+    </div>
+  );
+
   const renderDayEntries = (day: MyCalendarDay | undefined) => (
     <>
-      {(day?.entries ?? []).map((entry) => (
-        <div className="mycal-entry" key={entry.id}>
-          <div className="mycal-entry__body">
-            <h3 className="mycal-entry__company">{entry.companyName}</h3>
-            {entry.url && (
-              <a
-                className="mycal-entry__link"
-                href={entry.url}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                공고 열기
-              </a>
-            )}
-            {entry.memo && <p className="mycal-entry__memo">{entry.memo}</p>}
-          </div>
-          <div className="mycal-entry__actions">
-            <IonButton size="small" fill="clear" onClick={() => setForm(toForm(entry))}>
-              수정
-            </IonButton>
-            <IonButton size="small" fill="clear" color="danger" onClick={() => setDeleteTargetId(entry.id)}>
-              삭제
-            </IonButton>
-          </div>
-        </div>
-      ))}
+      {(day?.entries ?? []).map(renderEntry)}
       {(day?.entries.length ?? 0) === 0 && (
         <p className="mycal-detail__placeholder">
           이 날에 적어 둔 일정이 없습니다.<br />
@@ -319,6 +368,35 @@ const MyCalendar: React.FC = () => {
   );
 
   const dayPanelTitle = `${formatDateLabel(selectedDate)} 일정 ${selectedDay?.count ?? 0}건`;
+
+  /**
+   * 마감일 없는 상시채용. 달력 칸에 찍을 날짜가 없어 달력 아래에 따로 모아 둔다.
+   * 어느 달을 보고 있어도 같은 목록이므로 달을 넘겨도 그대로 남는다.
+   */
+  const renderOngoingSection = (month: MyCalendarMonth) => (
+    <section className="mycal-ongoing">
+      <h2 className="mycal-ongoing__title">
+        상시채용 <strong>{month.ongoingCount}건</strong>
+        <span className="mycal-ongoing__note">마감일이 없어 달력에 찍지 않습니다. 지원했으면 완료를 눌러 주세요.</span>
+      </h2>
+      {month.ongoingEntries.length === 0 ? (
+        <p className="mycal-detail__placeholder">
+          적어 둔 상시채용이 없습니다.<br />
+          마감일 없는 공고를 여기에 모아 두세요.
+        </p>
+      ) : (
+        month.ongoingEntries.map(renderEntry)
+      )}
+      <IonButton
+        expand="block"
+        size="small"
+        className="mycal-add-btn"
+        onClick={() => setForm(emptyForm(selectedDate, true))}
+      >
+        + 상시채용 추가
+      </IonButton>
+    </section>
+  );
 
   const renderCalendar = () => {
     if (loading) {
@@ -359,6 +437,8 @@ const MyCalendar: React.FC = () => {
             </aside>
           )}
         </div>
+
+        {renderOngoingSection(data)}
       </>
     );
   };
@@ -441,13 +521,29 @@ const MyCalendar: React.FC = () => {
               </IonButton>
             </header>
 
+            {/* 상시채용은 마감일이 없다. 체크하면 날짜 입력을 잠그고 상시채용 목록으로 보낸다. */}
+            <label className="mycal-field mycal-field--check">
+              <input
+                type="checkbox"
+                checked={form.ongoing}
+                onChange={(e) => setForm({ ...form, ongoing: e.target.checked })}
+              />
+              <span className="mycal-field__label">상시채용 (마감일 없음)</span>
+            </label>
+
             <label className="mycal-field">
               <span className="mycal-field__label">날짜</span>
               <input
                 type="date"
                 value={form.applyDate}
+                disabled={form.ongoing}
                 onChange={(e) => setForm({ ...form, applyDate: e.target.value })}
               />
+              {form.ongoing && (
+                <span className="mycal-field__hint">
+                  상시채용은 날짜 없이 저장되어 달력 아래 목록에 모입니다.
+                </span>
+              )}
             </label>
 
             <label className="mycal-field">


### PR DESCRIPTION
백엔드: kingle1024/nklcbdty-service#221 (먼저 머지·배포되어야 동작한다)

## 무엇

- 달력 아래에 **상시채용** 목록. 마감일이 없어 칸에 찍을 날짜가 없는 공고를 여기에 모은다. 특정 달의 것이 아니므로 달을 넘겨도 그대로 남는다.
- 등록 폼에 **"상시채용 (마감일 없음)"** 체크박스. 켜면 날짜 입력을 잠그고 안내 문구를 띄운다.
- 일정마다 **완료 / 되돌리기** 버튼. 날짜 있는 일정에도 쓴다.

## 판단한 것들

- **완료한 일정을 지우지 않는다.** 흐리게 + 취소선으로 남긴다 — 어디에 지원했는지가 기록으로 남아야 한다. 달력 칸의 칩에도 `✓` 를 붙여 한눈에 보인다.
- **완료 배지는 `inline-block`.** 회사명에 걸린 취소선은 자식에게 그대로 그려지고 `text-decoration: none` 으로는 지워지지 않는다. `inline-block` 이 그 전파를 끊는다.
- **체크를 풀었을 때 고를 날짜가 있어야 하니** `applyDate` 는 상시채용일 때도 폼에 그대로 들고 있는다. 저장할 때만 버려진다.
- **모바일에서 버튼이 세 개가 됐다.** `min-width: 0` 만 두면 회사명이 0까지 줄어들어 버튼이 절대 안 접히므로, 본문에 `flex: 1 1 60%` 를 줘서 안 들어갈 때만 다음 줄로 내려가게 했다.

## 확인

- `tsc --noEmit` 통과, 프로덕션 빌드 성공 (경고는 전부 손대지 않은 파일들의 기존 경고).
- 빌드 결과를 이 계약대로 응답하는 스텁 서버에 붙여 실제로 눌러 봤다:
  - 상시채용 3건 + 완료한 것 1건이 맨 아래로 정렬되어 표시
  - `+ 상시채용 추가` → 체크박스 켜진 상태로 열림, 날짜 입력 잠김 → 저장 시 `{"ongoing":true,...}` 로 POST → 목록에 뜸
  - `완료` 클릭 → 서버 반영 후 완료 안 한 것이 위로 재정렬, 버튼이 `되돌리기` 로 바뀜
  - 다음 달로 넘겨도 상시채용 4건 유지, 그 달 일정 건수는 0건으로 따로 셈
- Ionic 오버레이(모달·알럿)의 실제 애니메이션은 이 환경에서 확인하지 못했다 — 브라우저 창이 화면에 안 떠서 Ionic 이 하이드레이션을 끝내지 못한다. 폼 안의 값·잠김 상태와 CSS 계산값은 DOM 으로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)