### PR TITLE
🚨 Fix: 상시채용을 모르는 옛 서버에서 나의 캘린더가 빈 화면이 된다

### DIFF
--- a/src/common/myCalendarApi.ts
+++ b/src/common/myCalendarApi.ts
@@ -69,13 +69,39 @@ const messageOf = (error: unknown, fallback: string): string => {
   return fallback;
 };
 
+/*
+ * 상시채용·완료를 모르는 옛 서버는 ongoingEntries / ongoing / completed 를 안 보낸다.
+ * 그대로 쓰면 화면이 undefined.length 로 죽고, 체크박스가 controlled ↔ uncontrolled 를
+ * 넘나든다. 프론트는 Netlify 로 즉시 뜨는데 백엔드는 콘솔에서 손으로 재배포해야 해서
+ * 둘의 시차는 늘 생긴다 — 빠진 값은 이 한 곳에서 채우고 화면은 몰라도 되게 한다.
+ *
+ * 서버가 새 필드를 보내기 시작하면 이 함수는 아무것도 바꾸지 않는 통과 지점이 된다.
+ */
+const entryWithDefaults = (entry: MyCalendarEntry): MyCalendarEntry => ({
+  ...entry,
+  applyDate: entry.applyDate ?? null,
+  ongoing: entry.ongoing ?? entry.applyDate == null,
+  completed: entry.completed ?? false,
+  completedAt: entry.completedAt ?? null,
+});
+
+const withDefaults = (month: MyCalendarMonth): MyCalendarMonth => ({
+  ...month,
+  days: (month.days ?? []).map((day) => ({
+    ...day,
+    entries: (day.entries ?? []).map(entryWithDefaults),
+  })),
+  ongoingEntries: (month.ongoingEntries ?? []).map(entryWithDefaults),
+  ongoingCount: month.ongoingCount ?? 0,
+});
+
 export const fetchMyCalendarMonth = async (year: number, month: number): Promise<MyCalendarMonth> => {
   try {
     const res = await axios.get<MyCalendarMonth>(`${API_URL}/api/my-calendar/entries`, {
       params: { year, month },
       headers: authHeaders(),
     });
-    return res.data;
+    return withDefaults(res.data);
   } catch (error) {
     throw new Error(messageOf(error, '캘린더를 불러오지 못했습니다.'));
   }


### PR DESCRIPTION
## 지금 운영에서 깨져 있다

#58 을 머지하니 프론트는 Netlify 로 바로 떴는데, 백엔드(kingle1024/nklcbdty-service#221)는 **아직 안 떴다**. `docker-publish.yml` 의 Deploy 잡이 `vars.CLOUDTYPE_PROJECT` 가 비어 있어 skip 되기 때문이다.

그 사이 옛 서버는 `ongoingEntries` 를 안 보내고, 새 화면은 `month.ongoingEntries.length` 를 읽는다 → `undefined.length` → **`/mypage/calendar` 가 통째로 백지**.

## 무엇

빠진 필드를 API 계층에서 채운다. 화면은 시차를 몰라도 되게 한다.

- `ongoingEntries` / `ongoingCount` → 빈 목록, 0
- entry 의 `completed` / `completedAt` → false, null
- entry 의 `ongoing` → `applyDate == null` 로 판단 (서버 없이도 알 수 있는 값이다)

`ongoing`·`completed` 를 안 채우면 체크박스가 controlled ↔ uncontrolled 를 넘나들며 React 경고가 난다. 그래서 목록만이 아니라 항목 안까지 채운다.

서버가 새 필드를 보내기 시작하면 이 함수는 아무것도 바꾸지 않는 통과 지점이 된다 — 나중에 지울 임시 코드가 아니라, 배포 시차에 대한 상시 방어다.

## 확인

새 필드를 하나도 안 보내는 스텁 서버(= 지금 운영 백엔드)에 붙여 두 빌드를 비교했다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 콘솔 | `TypeError: Cannot read properties of undefined (reading 'length')` | 새 오류 없음 |
| 달력 칸 | 0개 (백지, `body.innerText` 길이 0) | 36개 |
| 상시채용 영역 | 렌더 안 됨 | "상시채용 0건" + 안내 문구 |
| 그 달 일정 | 렌더 안 됨 | "8월에 적어 둔 일정 1건" + 건수 배지 |

`tsc --noEmit` 통과, 프로덕션 빌드 성공.

## 남은 일 (이 PR 밖)

백엔드는 여전히 옛 빌드다. 클라우드타입 콘솔에서 재배포해야 상시채용이 실제로 저장된다. 그때까지 이 PR 덕에 화면은 "상시채용 0건" 으로 멀쩡히 보이고, 완료 버튼을 누르면 404 → "완료로 표시하지 못했습니다" 안내가 뜬다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar data handling when optional or legacy fields are missing.
  * Ensured dates, completion statuses, ongoing indicators, collections, and counts consistently display with appropriate default values.
  * Calendar month results now load reliably across varying API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->