### PR TITLE
✨ Feat: 트러블슈팅 기록 열람 화면 (/admin/troubleshooting)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,8 @@ import Email from './pages/EmailInquiry';
 import AdminHome from './pages/AdminHome';
 import AdminSubscriptions from './pages/AdminSubscriptions';
 import AdminJobDeleteRequests from './pages/AdminJobDeleteRequests';
+import AdminTroubleshooting from './pages/AdminTroubleshooting';
+import AdminTroubleshootingDetail from './pages/AdminTroubleshootingDetail';
 import Board from './pages/Board';
 import BoardDetail from './pages/BoardDetail';
 import BoardWrite from './pages/BoardWrite';
@@ -66,6 +68,15 @@ const App: React.FC = () => {
               <Route path='/admin' component={AdminHome} exact={true} />
               <Route path='/admin/subscriptions' component={AdminSubscriptions} exact={true} />
               <Route path='/admin/job-delete-requests' component={AdminJobDeleteRequests} exact={true} />
+
+              {/* 트러블슈팅 기록 열람. slug 는 영문 kebab-case 라 목록 경로와 겹치지 않지만,
+                  IonRouterOutlet 은 Switch 처럼 첫 매치만 쓰지 않으므로 둘 다 exact 로 못박는다 */}
+              <Route path='/admin/troubleshooting' component={AdminTroubleshooting} exact={true} />
+              <Route
+                path='/admin/troubleshooting/:slug'
+                component={AdminTroubleshootingDetail}
+                exact={true}
+              />
 
               {/* 자유게시판. :id 를 숫자로 못박아 /board/write 가 글 id 로 잡히지 않게 한다
                   (IonRouterOutlet 은 Switch 처럼 첫 매치만 쓰지 않아서 순서만으로는 부족하다) */}

--- a/src/common/AdminSidebar.tsx
+++ b/src/common/AdminSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { IonIcon } from '@ionic/react';
-import { gridOutline, peopleOutline, trashOutline, homeOutline, logOutOutline } from 'ionicons/icons';
+import { gridOutline, peopleOutline, trashOutline, homeOutline, logOutOutline, bugOutline } from 'ionicons/icons';
 import { clearAdminAuth } from './adminApi';
 
 // 관리자 페이지 공통 사이드바. 신규 관리자 메뉴는 여기 MENU 에 추가하면 모든 관리자 페이지에 노출됨.
@@ -9,6 +9,7 @@ const MENU: Array<{ label: string; path: string; icon: string }> = [
   { label: '관리자 홈', path: '/admin', icon: gridOutline },
   { label: '구독 관리', path: '/admin/subscriptions', icon: peopleOutline },
   { label: '공고 삭제요청', path: '/admin/job-delete-requests', icon: trashOutline },
+  { label: '트러블슈팅 기록', path: '/admin/troubleshooting', icon: bugOutline },
 ];
 
 const AdminSidebar: React.FC = () => {
@@ -36,7 +37,11 @@ const AdminSidebar: React.FC = () => {
       </div>
       <nav style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
         {MENU.map((m) => {
-          const active = location.pathname === m.path;
+          // 하위 화면(예: /admin/troubleshooting/<slug>)에서도 그 메뉴가 켜져 있어야 한다.
+          // '/admin' 은 모든 관리자 경로의 앞부분이라 정확히 일치할 때만 켠다.
+          const active =
+            location.pathname === m.path ||
+            (m.path !== '/admin' && location.pathname.startsWith(`${m.path}/`));
           return (
             <button
               key={m.path}

--- a/src/common/troubleshootingApi.ts
+++ b/src/common/troubleshootingApi.ts
@@ -1,0 +1,164 @@
+// 트러블슈팅 기록 열람 API. 백엔드 AdminTroubleshootingController(/api/admin/troubleshooting) 와 짝이다.
+//
+// 기록을 쓰는 쪽은 이 화면이 아니다 — 로컬의 save-troubleshooting 스킬이 DB 에 직접 넣고,
+// 여기서는 읽기만 한다. 그래서 create/update/delete 가 없다.
+//
+// 기록에 사내·고객사 시스템 이름과 로그 원문이 그대로 들어 있어 관리자 경로에 둔다.
+// adminApi 를 쓰므로 토큰이 자동으로 붙고, 401 이면 /admin 으로 되돌아간다.
+import axios from 'axios';
+import adminApi from './adminApi';
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low';
+
+export interface TroubleshootingSummary {
+  id: number;
+  slug: string;
+  /** 장애 발생일(YYYY-MM-DD). 기록한 날이 아니다 */
+  occurredOn: string;
+  project: string;
+  component: string | null;
+  title: string;
+  severity: string | null;
+  errorCode: string | null;
+  /** 한 줄 교훈. 목록에서 미리보기로 쓴다 */
+  lesson: string | null;
+  tags: string[];
+  techStack: string[];
+  hasReferences: boolean;
+  updatedAt: string | null;
+}
+
+/** 참고 링크 한 줄. url 이 없으면 링크가 아니라 메모(커밋 해시 등)다 */
+export interface ReferenceLink {
+  label: string;
+  url: string | null;
+}
+
+export interface TroubleshootingDetail {
+  id: number;
+  slug: string;
+  occurredOn: string;
+  project: string;
+  component: string | null;
+  title: string;
+  severity: string | null;
+  errorCode: string | null;
+  symptom: string | null;
+  rootCause: string | null;
+  resolution: string | null;
+  verification: string | null;
+  prevention: string | null;
+  lesson: string | null;
+  techStack: string[];
+  tags: string[];
+  referenceLinks: ReferenceLink[];
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface TroubleshootingPage {
+  rows: TroubleshootingSummary[];
+  totalElements: number;
+  totalPages: number;
+  pageNumber: number;
+  pageSize: number;
+  /** 필터 적용 전 전체 건수 */
+  totalNotes: number;
+  projects: string[];
+  tags: string[];
+  severityCounts: Record<string, number>;
+}
+
+export interface TroubleshootingQuery {
+  keyword?: string;
+  project?: string;
+  severity?: string;
+  tag?: string;
+  page?: number;
+  size?: number;
+}
+
+const BASE = '/api/admin/troubleshooting';
+
+/** 서버가 준 메세지를 꺼낸다. 없으면 기본 문구 (boardApi 와 같은 방식) */
+const messageOf = (error: unknown, fallback: string): string => {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { message?: string } | undefined;
+    if (data?.message) {
+      return data.message;
+    }
+    if (!error.response) {
+      return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.';
+    }
+  }
+  return fallback;
+};
+
+export const fetchNotes = async (query: TroubleshootingQuery): Promise<TroubleshootingPage> => {
+  // 빈 값은 보내지 않는다 — 서버가 빈 문자열을 "조건 없음" 으로 보긴 하지만,
+  // 주소가 지저분해지고 캐시 키가 갈라진다
+  const params: Record<string, string | number> = {
+    page: query.page ?? 0,
+    size: query.size ?? 20,
+  };
+  if (query.keyword) params.keyword = query.keyword;
+  if (query.project) params.project = query.project;
+  if (query.severity) params.severity = query.severity;
+  if (query.tag) params.tag = query.tag;
+
+  try {
+    const { data } = await adminApi.get<TroubleshootingPage>(BASE, { params });
+    return data;
+  } catch (error) {
+    throw new Error(messageOf(error, '기록 목록을 가져오지 못했습니다.'));
+  }
+};
+
+export const fetchNote = async (slug: string): Promise<TroubleshootingDetail> => {
+  try {
+    const { data } = await adminApi.get<TroubleshootingDetail>(`${BASE}/${encodeURIComponent(slug)}`);
+    return data;
+  } catch (error) {
+    throw new Error(messageOf(error, '기록을 가져오지 못했습니다.'));
+  }
+};
+
+/** 화면에 쓰는 심각도 표기. 저장된 값이 넷 중 하나가 아니어도 그대로 보여준다 */
+export const severityMeta = (
+  severity: string | null
+): { label: string; className: string } => {
+  switch ((severity ?? '').toLowerCase()) {
+    case 'critical':
+      return { label: 'critical', className: 'ts-sev critical' };
+    case 'high':
+      return { label: 'high', className: 'ts-sev high' };
+    case 'medium':
+      return { label: 'medium', className: 'ts-sev medium' };
+    case 'low':
+      return { label: 'low', className: 'ts-sev low' };
+    default:
+      return { label: severity || '미지정', className: 'ts-sev unknown' };
+  }
+};
+
+/** 발생일(YYYY-MM-DD)을 'YYYY.MM.DD' 로. 서버가 날짜만 주므로 시간대 변환을 하지 않는다 */
+export const formatOccurredOn = (value: string | null): string => {
+  if (!value) {
+    return '-';
+  }
+  const parts = value.split('-');
+  return parts.length === 3 ? `${parts[0]}.${parts[1]}.${parts[2]}` : value;
+};
+
+/** 저장 시각 표기(연월일 + 시:분) */
+export const formatStamp = (value: string | null): string => {
+  if (!value) {
+    return '-';
+  }
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return value;
+  }
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}.${pad(date.getMonth() + 1)}.${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};

--- a/src/pages/AdminHome.tsx
+++ b/src/pages/AdminHome.tsx
@@ -8,7 +8,7 @@ import {
   IonSpinner,
   IonIcon,
 } from '@ionic/react';
-import { lockClosedOutline, peopleOutline, trashOutline, logOutOutline } from 'ionicons/icons';
+import { lockClosedOutline, peopleOutline, trashOutline, logOutOutline, bugOutline } from 'ionicons/icons';
 import { Helmet } from 'react-helmet';
 import CommonHeader from '../common/CommonHeader';
 import AdminSidebar from '../common/AdminSidebar';
@@ -142,6 +142,13 @@ const AdminHome: React.FC = () => {
                 <div>
                   <div style={{ fontWeight: 700 }}>공고 삭제요청</div>
                   <div style={{ fontSize: 13, color: '#888' }}>삭제요청 검토(승인/반려)</div>
+                </div>
+              </div>
+              <div style={cardStyle} onClick={() => history.push('/admin/troubleshooting')}>
+                <IonIcon icon={bugOutline} style={{ fontSize: 28, color: '#059669' }} />
+                <div>
+                  <div style={{ fontWeight: 700 }}>트러블슈팅 기록</div>
+                  <div style={{ fontSize: 13, color: '#888' }}>해결한 장애 기록 열람</div>
                 </div>
               </div>
             </div>

--- a/src/pages/AdminTroubleshooting.css
+++ b/src/pages/AdminTroubleshooting.css
@@ -1,0 +1,474 @@
+/* 트러블슈팅 기록 열람(목록/상세) 스타일. 색·모양은 theme.css 토큰을 그대로 쓴다. */
+
+.ts-layout {
+  display: flex;
+  align-items: flex-start;
+}
+
+.ts-main {
+  flex: 1;
+  min-width: 0;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+/* 머리말 */
+.ts-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.ts-head h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.ts-head p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+/* 심각도 요약 — 전체 기준 집계라 필터를 걸어도 숫자가 바뀌지 않는다 */
+.ts-stats {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.ts-stat {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.ts-stat.selected {
+  border-color: var(--brand-primary);
+  background: var(--brand-primary-tint);
+  color: var(--brand-primary);
+  font-weight: 700;
+}
+
+.ts-stat-num {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.ts-stat.selected .ts-stat-num {
+  color: var(--brand-primary);
+}
+
+/* 검색 + 프로젝트 선택 */
+.ts-filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.ts-filters input,
+.ts-filters select {
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--text-body);
+  background-color: var(--surface-field);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+}
+
+.ts-filters input {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.ts-filters select {
+  flex: 0 1 240px;
+  max-width: 100%;
+}
+
+.ts-filters input:focus,
+.ts-filters select:focus {
+  border-color: var(--brand-primary);
+}
+
+/* 태그 필터 */
+.ts-tagbar {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.ts-tag {
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  background: var(--surface-field);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+
+.ts-tag:hover {
+  border-color: var(--border);
+}
+
+.ts-tag.selected {
+  color: #ffffff;
+  background: var(--brand-primary);
+  font-weight: 700;
+}
+
+/* 태그가 많아 접어 둘 때 쓰는 '더 보기' */
+.ts-tag.more {
+  background: transparent;
+  color: var(--brand-primary);
+  font-weight: 600;
+}
+
+/* 적용된 조건 안내 */
+.ts-applied {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.ts-applied button {
+  margin-left: 8px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  background: var(--surface-field);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+
+/* 목록 */
+.ts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ts-card {
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  cursor: pointer;
+}
+
+.ts-card:hover {
+  box-shadow: var(--shadow-card-hover);
+}
+
+.ts-card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.ts-card-date {
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.ts-card-title {
+  margin: 0 0 6px;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.45;
+  color: var(--text-strong);
+  word-break: break-word;
+}
+
+.ts-card-lesson {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.ts-card-tags {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.ts-card-tags span {
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--surface-field);
+  border-radius: var(--radius-pill);
+}
+
+/* 심각도 뱃지 */
+.ts-sev {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.ts-sev.critical {
+  color: #ffffff;
+  background: var(--danger);
+}
+
+.ts-sev.high {
+  color: var(--danger);
+  background: var(--danger-tint);
+}
+
+.ts-sev.medium {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.ts-sev.low {
+  color: var(--success);
+  background: var(--success-tint);
+}
+
+.ts-sev.unknown {
+  color: var(--text-muted);
+  background: var(--surface-field);
+}
+
+/* 코드처럼 보여주는 식별자(에러 코드, slug) */
+.ts-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  background: var(--surface-field);
+  word-break: break-all;
+}
+
+.ts-empty {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.ts-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 24px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+/* 페이징 — 게시판과 같은 모양 */
+.ts-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 20px;
+  flex-wrap: wrap;
+}
+
+.ts-page-btn {
+  min-width: 34px;
+  height: 34px;
+  padding: 0 8px;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.ts-page-btn:disabled {
+  color: var(--text-disabled);
+  cursor: default;
+}
+
+.ts-page-btn.current {
+  color: #ffffff;
+  background-color: var(--brand-primary);
+  border-color: var(--brand-primary);
+  font-weight: 700;
+}
+
+/* ── 상세 ── */
+.ts-detail {
+  padding: 24px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.ts-detail-title {
+  margin: 8px 0 10px;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--text-strong);
+  word-break: break-word;
+}
+
+.ts-detail-meta {
+  display: flex;
+  gap: 8px 16px;
+  flex-wrap: wrap;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.ts-detail-meta b {
+  margin-right: 4px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+/* 본문 절 */
+.ts-section {
+  padding: 20px 0;
+  border-bottom: 1px solid var(--divider);
+}
+
+.ts-section:last-of-type {
+  border-bottom: none;
+}
+
+.ts-section h2 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.ts-section h2 .ts-section-hint {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+/* 저장된 원문을 손대지 않고 보여준다 — 줄바꿈과 로그 들여쓰기가 내용의 일부다 */
+.ts-body {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.75;
+  color: var(--text-body);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* 에러 메시지 원문이 섞인 증상은 등폭으로 — 로그의 정렬이 살아 있어야 읽힌다 */
+.ts-body.log {
+  padding: 14px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  line-height: 1.7;
+  background: var(--surface-field);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+
+/* 한 줄 교훈은 눈에 띄게 */
+.ts-lesson {
+  margin: 0;
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text-strong);
+  background: var(--brand-primary-tint);
+  border-left: 3px solid var(--brand-primary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  word-break: break-word;
+}
+
+.ts-links {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ts-links li {
+  font-size: 13px;
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+
+.ts-links a {
+  color: var(--brand-primary);
+  text-decoration: none;
+}
+
+.ts-links a:hover {
+  text-decoration: underline;
+}
+
+.ts-detail-foot {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  /* 좁은 화면에서는 관리자 사이드바를 접고 본문만 남긴다 */
+  .ts-layout > aside {
+    display: none;
+  }
+
+  .ts-main {
+    padding: 12px;
+  }
+
+  .ts-detail {
+    padding: 16px;
+  }
+
+  .ts-head {
+    flex-direction: column;
+  }
+}

--- a/src/pages/AdminTroubleshooting.tsx
+++ b/src/pages/AdminTroubleshooting.tsx
@@ -1,0 +1,333 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
+import { IonPage, IonContent, IonButton, IonSpinner, IonIcon, IonAlert } from '@ionic/react';
+import { refreshOutline, linkOutline } from 'ionicons/icons';
+import { Helmet } from 'react-helmet';
+import CommonHeader from '../common/CommonHeader';
+import AdminSidebar from '../common/AdminSidebar';
+import { isAdminLoggedIn } from '../common/adminApi';
+import {
+  TroubleshootingPage,
+  fetchNotes,
+  formatOccurredOn,
+  severityMeta,
+} from '../common/troubleshootingApi';
+import './AdminTroubleshooting.css';
+
+const PAGE_SIZE = 20;
+
+/** 태그가 수십 개라 처음에는 이만큼만 보여주고 나머지는 접는다 */
+const TAGS_COLLAPSED = 12;
+
+/** 페이징 버튼에 보여줄 페이지 번호(현재 페이지 기준 최대 5개) */
+const pageNumbers = (current: number, totalPages: number): number[] => {
+  const start = Math.max(0, Math.min(current - 2, totalPages - 5));
+  const end = Math.min(totalPages, start + 5);
+  const numbers: number[] = [];
+  for (let i = start; i < end; i += 1) {
+    numbers.push(i);
+  }
+  return numbers;
+};
+
+/**
+ * 트러블슈팅 기록 목록.
+ *
+ * 기록은 로컬의 save-troubleshooting 스킬이 DB(troubleshooting_note)에 넣고, 이 화면은 읽기만 한다.
+ * 그래서 글쓰기 버튼이 없다. 찾는 방법을 세 가지 둔 이유는 기록을 다시 꺼내는 실마리가
+ * 그때그때 다르기 때문이다 — 프로젝트가 기억날 때, 태그가 기억날 때, 에러 메시지만 기억날 때.
+ */
+const AdminTroubleshooting: React.FC = () => {
+  const history = useHistory();
+  const location = useLocation();
+
+  const [result, setResult] = useState<TroubleshootingPage | null>(null);
+  const [page, setPage] = useState(0);
+  // 입력 중인 검색어와 실제 조회에 쓰는 검색어를 나눠 타이핑마다 조회하지 않는다
+  const [keywordInput, setKeywordInput] = useState('');
+  const [keyword, setKeyword] = useState('');
+  const [project, setProject] = useState('');
+  const [severity, setSeverity] = useState('');
+  const [tag, setTag] = useState('');
+  const [showAllTags, setShowAllTags] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  // 미로그인 시 관리자 로그인(/admin)으로 보낸다
+  useEffect(() => {
+    if (!isAdminLoggedIn()) {
+      history.replace('/admin');
+    }
+  }, [history]);
+
+  // 주소에 실린 조건을 반영한다. 상세 화면에서 태그를 눌러 돌아오는 길
+  // (/admin/troubleshooting?tag=race-condition)이 이걸로 이어진다.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const nextKeyword = params.get('keyword') ?? '';
+    setKeyword(nextKeyword);
+    setKeywordInput(nextKeyword);
+    setProject(params.get('project') ?? '');
+    setSeverity(params.get('severity') ?? '');
+    setTag(params.get('tag') ?? '');
+    setPage(0);
+  }, [location.search]);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      setResult(await fetchNotes({ keyword, project, severity, tag, page, size: PAGE_SIZE }));
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '기록 목록을 가져오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [keyword, project, severity, tag, page]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleSearch = () => {
+    setPage(0);
+    setKeyword(keywordInput.trim());
+  };
+
+  /** 같은 값을 다시 누르면 해제된다 — 조건을 지우려고 드롭다운을 찾지 않게 */
+  const toggleSeverity = (value: string) => {
+    setPage(0);
+    setSeverity((prev) => (prev === value ? '' : value));
+  };
+
+  const toggleTag = (value: string) => {
+    setPage(0);
+    setTag((prev) => (prev === value ? '' : value));
+  };
+
+  const clearFilters = () => {
+    // 주소에 조건이 실려 들어온 경우(상세에서 태그를 눌러 온 길)에는 주소도 같이 비운다.
+    // 그러지 않으면 화면은 비어 있는데 주소는 조건을 들고 있어, 새로고침하면 되살아난다.
+    if (location.search) {
+      history.replace('/admin/troubleshooting');
+      return;
+    }
+    setPage(0);
+    setKeyword('');
+    setKeywordInput('');
+    setProject('');
+    setSeverity('');
+    setTag('');
+  };
+
+  const rows = result?.rows ?? [];
+  const totalPages = result?.totalPages ?? 0;
+  // 필터 후보와 집계는 서버가 전체 기준으로 준다. 필터를 걸어도 선택지가 사라지지 않는다.
+  const projects = result?.projects ?? [];
+  const allTags = result?.tags ?? [];
+  // 걸려 있는 태그는 접힌 뒤쪽에 있어도 반드시 보여준다. 상세에서 태그를 눌러 들어오면
+  // (?tag=logback) 흔한 태그가 아닐 때가 많아, 안 보이면 무엇으로 좁혀졌는지 알 수 없다.
+  const visibleTags = showAllTags
+    ? allTags
+    : tag && !allTags.slice(0, TAGS_COLLAPSED).includes(tag)
+      ? [tag, ...allTags.slice(0, TAGS_COLLAPSED - 1)]
+      : allTags.slice(0, TAGS_COLLAPSED);
+  const hiddenTagCount = allTags.length - visibleTags.filter((t) => allTags.includes(t)).length;
+  const severityCounts = result?.severityCounts ?? {};
+  const hasFilter = !!(keyword || project || severity || tag);
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>관리자 - 트러블슈팅 기록</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="해결한 장애 기록 열람" />
+      </Helmet>
+      <CommonHeader />
+      <IonContent>
+        <div className="ts-layout">
+          <AdminSidebar />
+          <div className="ts-main">
+            <header className="ts-head">
+              <div>
+                <h1>트러블슈팅 기록</h1>
+                <p>
+                  해결한 장애를 원인·해결·검증까지 남겨 둔 기록입니다.
+                  {result ? ` 전체 ${result.totalNotes}건.` : ''}
+                </p>
+              </div>
+              <IonButton fill="outline" size="default" onClick={load} disabled={isLoading}>
+                <IonIcon slot="start" icon={refreshOutline} />
+                새로고침
+              </IonButton>
+            </header>
+
+            {/* 심각도 요약 겸 필터. 숫자는 전체 기준이라 필터를 걸어도 변하지 않는다 */}
+            {Object.keys(severityCounts).length > 0 && (
+              <div className="ts-stats">
+                {Object.entries(severityCounts).map(([level, count]) => (
+                  <button
+                    key={level}
+                    type="button"
+                    className={`ts-stat${severity === level ? ' selected' : ''}`}
+                    onClick={() => toggleSeverity(level)}
+                  >
+                    <span className="ts-stat-num">{count}</span>
+                    <span>{level}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <div className="ts-filters">
+              <input
+                value={keywordInput}
+                onChange={(e) => setKeywordInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSearch();
+                  }
+                }}
+                placeholder="제목·증상·원인·에러 코드·태그 검색"
+              />
+              <select
+                value={project}
+                onChange={(e) => {
+                  setPage(0);
+                  setProject(e.target.value);
+                }}
+              >
+                <option value="">전체 프로젝트</option>
+                {projects.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+              <IonButton size="small" fill="outline" onClick={handleSearch}>
+                검색
+              </IonButton>
+            </div>
+
+            {allTags.length > 0 && (
+              <div className="ts-tagbar">
+                {visibleTags.map((name) => (
+                  <button
+                    key={name}
+                    type="button"
+                    className={`ts-tag${tag === name ? ' selected' : ''}`}
+                    onClick={() => toggleTag(name)}
+                  >
+                    #{name}
+                  </button>
+                ))}
+                {(showAllTags || hiddenTagCount > 0) && (
+                  <button
+                    type="button"
+                    className="ts-tag more"
+                    onClick={() => setShowAllTags((v) => !v)}
+                  >
+                    {showAllTags ? '접기' : `+${hiddenTagCount} 더 보기`}
+                  </button>
+                )}
+              </div>
+            )}
+
+            {hasFilter && (
+              <p className="ts-applied">
+                {result ? `${result.totalElements}건` : '조회 중'}
+                {keyword ? ` · 검색 '${keyword}'` : ''}
+                {project ? ` · ${project}` : ''}
+                {severity ? ` · ${severity}` : ''}
+                {tag ? ` · #${tag}` : ''}
+                <button type="button" onClick={clearFilters}>
+                  조건 지우기
+                </button>
+              </p>
+            )}
+
+            {isLoading ? (
+              <div className="ts-loading">
+                <IonSpinner name="crescent" />
+                <span>기록을 불러오는 중...</span>
+              </div>
+            ) : rows.length === 0 ? (
+              <div className="ts-empty">
+                {hasFilter ? '조건에 맞는 기록이 없습니다.' : '저장된 기록이 없습니다.'}
+              </div>
+            ) : (
+              <div className="ts-list">
+                {rows.map((note) => {
+                  const sev = severityMeta(note.severity);
+                  return (
+                    <div
+                      key={note.slug}
+                      className="ts-card"
+                      onClick={() => history.push(`/admin/troubleshooting/${note.slug}`)}
+                    >
+                      <div className="ts-card-top">
+                        <span className="ts-card-date">{formatOccurredOn(note.occurredOn)}</span>
+                        <span className={sev.className}>{sev.label}</span>
+                        <span>{note.project}</span>
+                        {note.errorCode && <span className="ts-mono">{note.errorCode}</span>}
+                        {note.hasReferences && <IonIcon icon={linkOutline} title="참고 링크 있음" />}
+                      </div>
+                      <h2 className="ts-card-title">{note.title}</h2>
+                      {note.lesson && <p className="ts-card-lesson">{note.lesson}</p>}
+                      {note.tags.length > 0 && (
+                        <div className="ts-card-tags">
+                          {note.tags.slice(0, 8).map((name) => (
+                            <span key={name}>#{name}</span>
+                          ))}
+                          {note.tags.length > 8 && <span>+{note.tags.length - 8}</span>}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {totalPages > 1 && (
+              <div className="ts-pagination">
+                <button
+                  className="ts-page-btn"
+                  disabled={page === 0}
+                  onClick={() => setPage(page - 1)}
+                >
+                  이전
+                </button>
+                {pageNumbers(page, totalPages).map((number) => (
+                  <button
+                    key={number}
+                    className={`ts-page-btn${number === page ? ' current' : ''}`}
+                    onClick={() => setPage(number)}
+                  >
+                    {number + 1}
+                  </button>
+                ))}
+                <button
+                  className="ts-page-btn"
+                  disabled={page >= totalPages - 1}
+                  onClick={() => setPage(page + 1)}
+                >
+                  다음
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <IonAlert
+          isOpen={!!errorMessage}
+          onDidDismiss={() => setErrorMessage('')}
+          header="알림"
+          message={errorMessage}
+          buttons={['확인']}
+        />
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default AdminTroubleshooting;

--- a/src/pages/AdminTroubleshootingDetail.tsx
+++ b/src/pages/AdminTroubleshootingDetail.tsx
@@ -1,0 +1,213 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { IonPage, IonContent, IonButton, IonSpinner, IonIcon } from '@ionic/react';
+import { arrowBackOutline } from 'ionicons/icons';
+import { Helmet } from 'react-helmet';
+import CommonHeader from '../common/CommonHeader';
+import AdminSidebar from '../common/AdminSidebar';
+import { isAdminLoggedIn } from '../common/adminApi';
+import {
+  TroubleshootingDetail,
+  fetchNote,
+  formatOccurredOn,
+  formatStamp,
+  severityMeta,
+} from '../common/troubleshootingApi';
+import './AdminTroubleshooting.css';
+
+/**
+ * 기록 한 건. 저장할 때 나눠 둔 절(증상 → 원인 → 해결 → 검증 → 예방 → 교훈)을 그대로 보여준다.
+ *
+ * 순서를 이렇게 고정한 이유는 이 기록의 목적이 "고쳤다" 가 아니라 "어떻게 원인에 도달했는가" 라서다.
+ * 증상 → 원인 → 해결 순으로 읽히면 진단 과정이 남고, 해결부터 보여주면 결과만 남는다.
+ *
+ * 본문은 손대지 않고 그대로 내보낸다 — 증상에 넣어 둔 에러 메시지 원문이 나중에 검색 키가 된다.
+ */
+const SECTIONS: Array<{
+  key: keyof TroubleshootingDetail;
+  title: string;
+  hint?: string;
+  /** 로그·에러 메시지가 섞이는 절은 등폭으로 — 원문 정렬이 살아 있어야 읽힌다 */
+  log?: boolean;
+}> = [
+  { key: 'symptom', title: '증상', hint: '관측된 사실과 에러 메시지 원문', log: true },
+  { key: 'rootCause', title: '원인', hint: '직접 원인 → 그 원인 → 왜 하필 지금' },
+  { key: 'resolution', title: '해결', hint: '무엇을 왜 그렇게 고쳤는지' },
+  { key: 'verification', title: '검증', hint: '고쳐진 것을 어떻게 증명했는지' },
+  { key: 'prevention', title: '재발 방지' },
+];
+
+const AdminTroubleshootingDetail: React.FC = () => {
+  const history = useHistory();
+  const { slug } = useParams<{ slug: string }>();
+
+  const [note, setNote] = useState<TroubleshootingDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (!isAdminLoggedIn()) {
+      history.replace('/admin');
+    }
+  }, [history]);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage('');
+    try {
+      setNote(await fetchNote(slug));
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '기록을 가져오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [slug]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const sev = severityMeta(note?.severity ?? null);
+
+  return (
+    <IonPage>
+      <Helmet>
+        <title>{note ? `${note.title} - 트러블슈팅` : '트러블슈팅 기록'}</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Helmet>
+      <CommonHeader />
+      <IonContent>
+        <div className="ts-layout">
+          <AdminSidebar />
+          <div className="ts-main">
+            <IonButton
+              fill="clear"
+              size="small"
+              onClick={() => history.push('/admin/troubleshooting')}
+            >
+              <IonIcon slot="start" icon={arrowBackOutline} />
+              목록으로
+            </IonButton>
+
+            {isLoading ? (
+              <div className="ts-loading">
+                <IonSpinner name="crescent" />
+                <span>기록을 불러오는 중...</span>
+              </div>
+            ) : errorMessage || !note ? (
+              <div className="ts-empty">{errorMessage || '기록을 찾을 수 없습니다.'}</div>
+            ) : (
+              <article className="ts-detail">
+                <div className="ts-card-top">
+                  <span className="ts-card-date">{formatOccurredOn(note.occurredOn)}</span>
+                  <span className={sev.className}>{sev.label}</span>
+                  {note.errorCode && <span className="ts-mono">{note.errorCode}</span>}
+                </div>
+
+                <h1 className="ts-detail-title">{note.title}</h1>
+
+                <div className="ts-detail-meta">
+                  <span>
+                    <b>프로젝트</b>
+                    {note.project}
+                  </span>
+                  {note.component && (
+                    <span>
+                      <b>구성요소</b>
+                      {note.component}
+                    </span>
+                  )}
+                  {note.techStack.length > 0 && (
+                    <span>
+                      <b>기술</b>
+                      {note.techStack.join(', ')}
+                    </span>
+                  )}
+                </div>
+
+                {note.lesson && (
+                  <div className="ts-section">
+                    <h2>교훈</h2>
+                    <p className="ts-lesson">{note.lesson}</p>
+                  </div>
+                )}
+
+                {SECTIONS.map((section) => {
+                  const value = note[section.key];
+                  // 값이 비어 있는 절은 빈 제목만 남기지 않고 아예 그린다
+                  if (typeof value !== 'string' || !value.trim()) {
+                    return null;
+                  }
+                  return (
+                    <div className="ts-section" key={section.key as string}>
+                      <h2>
+                        {section.title}
+                        {section.hint && <span className="ts-section-hint">{section.hint}</span>}
+                      </h2>
+                      <p className={`ts-body${section.log ? ' log' : ''}`}>{value}</p>
+                    </div>
+                  );
+                })}
+
+                {note.tags.length > 0 && (
+                  <div className="ts-section">
+                    <h2>태그</h2>
+                    <div className="ts-tagbar">
+                      {note.tags.map((name) => (
+                        <button
+                          key={name}
+                          type="button"
+                          className="ts-tag"
+                          onClick={() =>
+                            history.push(
+                              `/admin/troubleshooting?tag=${encodeURIComponent(name)}`
+                            )
+                          }
+                        >
+                          #{name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {note.referenceLinks.length > 0 && (
+                  <div className="ts-section">
+                    <h2>참고</h2>
+                    <ul className="ts-links">
+                      {note.referenceLinks.map((link, index) => (
+                        <li key={`${link.label}-${index}`}>
+                          {link.url ? (
+                            // 외부 저장소·CI 로 나가는 링크. 기록 화면을 잃지 않게 새 탭으로 연다
+                            <a href={link.url} target="_blank" rel="noopener noreferrer">
+                              {link.label}
+                            </a>
+                          ) : (
+                            // 주소가 없는 줄(커밋 해시 등)은 링크로 만들지 않는다
+                            link.label
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                <div className="ts-detail-foot">
+                  <span className="ts-mono">{note.slug}</span>
+                  {' · '}
+                  기록 {formatStamp(note.createdAt)}
+                  {note.updatedAt && note.updatedAt !== note.createdAt
+                    ? ` · 갱신 ${formatStamp(note.updatedAt)}`
+                    : ''}
+                </div>
+              </article>
+            )}
+          </div>
+        </div>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default AdminTroubleshootingDetail;


### PR DESCRIPTION
## 무엇

DB 에 쌓아 둔 트러블슈팅 기록을 목록·상세로 보는 화면. 관리자 메뉴에 들어간다.

쓰는 쪽은 이 화면이 아니라 로컬의 `save-troubleshooting` 스킬이라 **읽기 전용**이고, 글쓰기 버튼이 없다.

- `/admin/troubleshooting` — 목록
- `/admin/troubleshooting/:slug` — 상세

백엔드: kingle1024/nklcbdty-service#226 (먼저 머지)

## 목록

- **심각도 타일**(critical/high/medium/low)이 집계 겸 필터다. 같은 값을 다시 누르면 풀린다 — 조건을 지우려고 드롭다운을 다시 찾지 않게.
- **검색**은 제목뿐 아니라 증상·원인·해결 본문과 에러 코드·태그까지 훑는다. 기록을 다시 찾는 실마리가 보통 에러 메시지 원문이다.
- **태그 칩**은 12개까지 펼치고 나머지는 접는다. 단 걸려 있는 태그는 접힌 뒤쪽에 있어도 반드시 보여준다 — 안 보이면 무엇으로 좁혀졌는지 알 수 없다(상세에서 태그를 눌러 들어오면 흔한 태그가 아닐 때가 많다).
- 필터 후보와 집계는 서버가 전체 기준으로 주므로, 한 건만 남게 좁혀도 **선택지가 사라지지 않는다.**

## 상세

- **증상 → 원인 → 해결 → 검증 → 재발 방지** 순서를 고정한다. 이 기록의 목적이 "고쳤다" 가 아니라 "어떻게 원인에 도달했는가" 라서, 해결부터 보여주면 결과만 남는다. 한 줄 교훈은 맨 위로 뽑는다.
- 본문은 손대지 않고 그대로 그린다(`white-space: pre-wrap`). **에러 메시지가 섞이는 증상 절만 등폭**으로 두고, 좁은 화면에서 자기 안에서만 가로 스크롤되게 했다 — 로그의 정렬이 살아 있어야 읽힌다.
- 참고 링크는 **주소가 있는 줄만** 링크로 만든다. `머지 커밋: abc1234` 처럼 주소가 없는 줄을 링크로 만들면 눌러도 갈 곳이 없다.
- 태그를 누르면 `?tag=...` 로 목록에 돌아간다. 주소로 들어온 조건은 '조건 지우기' 가 **주소까지** 비운다 — 안 그러면 화면은 비었는데 주소가 조건을 들고 있어 새로고침에 되살아난다.

## 라우팅

목록/상세 둘 다 `exact` 로 못박았다. `IonRouterOutlet` 은 `Switch` 처럼 첫 매치만 쓰지 않는다.

관리자 사이드바는 하위 경로(`/admin/troubleshooting/<slug>`)에서도 그 메뉴가 켜지도록 고쳤다. `/admin` 은 모든 관리자 경로의 앞부분이라 정확히 일치할 때만 켠다.

## 검증

목 백엔드에 **실제 기록 11건**을 실어 헤드리스 Chrome 으로 확인했다. 3,000자짜리 로그와 태그 열 개가 붙은 행으로 그려봐야 레이아웃이 무너지는지 알 수 있다.

| 확인한 것 | 결과 |
|---|---|
| 목록 렌더 | 카드 11건, 심각도 타일 `1 critical / 6 high / 4 medium`, 프로젝트 8개, 태그 칩 13개 |
| 심각도 필터 + 해제 | 1건으로 좁혀짐, 타일 3개·프로젝트 8개 그대로 유지, 다시 눌러 11건 복귀 |
| 본문 전문 검색 | 증상에만 있는 `Connection refused` → 1건 |
| 태그 필터 | `#silent-failure` → 4건 |
| 상세 절 순서 | 교훈 · 증상 · 원인 · 해결 · 검증 · 재발 방지 · 태그 · 참고 |
| 본문 보존 | 증상 블록 `pre-wrap` + 등폭, 링크 `target=_blank` |
| 상세→태그→목록 왕복 | `?tag=logback` 1건, 칩 선택 표시됨, '조건 지우기' 가 주소까지 비움 |
| 없는 slug | "해당 기록을 찾을 수 없습니다." |
| 미로그인 | `/admin` 로그인 화면으로 이동 |
| 가로 스크롤 | 1280 → 1280, 375 → 375 (넘침 없음). 모바일에서 사이드바 접힘, 로그 블록만 자체 스크롤 |

콘솔 에러 없음(남은 403 은 헤드리스에서 막히는 AdSense, 이 변경과 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin troubleshooting dashboard with searchable, filterable, and paginated incident records.
  * Added troubleshooting detail pages with severity, lessons, logs, tags, references, and timestamps.
  * Added dashboard and sidebar navigation for troubleshooting records.
  * Added tag-based filtering, refresh controls, loading states, empty states, and error alerts.
  * Added responsive layouts for troubleshooting list and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->