### PR TITLE
✨ Feat: 트러블슈팅 기록 전체 복사 버튼

### DIFF
--- a/src/common/troubleshootingApi.ts
+++ b/src/common/troubleshootingApi.ts
@@ -162,3 +162,93 @@ export const formatStamp = (value: string | null): string => {
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${date.getFullYear()}.${pad(date.getMonth() + 1)}.${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
+
+/**
+ * 기록 한 건을 텍스트로 만든다. Claude 에게 붙여 넣어 참고시키려는 용도라,
+ * 화면 모양이 아니라 **읽는 쪽이 구조를 알아볼 수 있는 형태**(마크다운)로 뽑는다.
+ *
+ * 비어 있는 절은 빈 제목만 남기지 않고 뺀다. 본문은 저장된 원문을 그대로 둔다 —
+ * 증상에 든 에러 메시지를 다듬으면 붙여 넣는 의미가 없어진다.
+ */
+export const noteToText = (note: TroubleshootingDetail): string => {
+  const lines: string[] = [`# ${note.title}`, ''];
+
+  const meta: Array<[string, string | null]> = [
+    ['발생일', formatOccurredOn(note.occurredOn)],
+    ['프로젝트', note.project],
+    ['구성요소', note.component],
+    ['심각도', note.severity],
+    ['에러 코드', note.errorCode],
+    ['기술', note.techStack.length ? note.techStack.join(', ') : null],
+    ['태그', note.tags.length ? note.tags.map((t) => `#${t}`).join(' ') : null],
+    ['slug', note.slug],
+  ];
+  for (const [label, value] of meta) {
+    if (value) {
+      lines.push(`- ${label}: ${value}`);
+    }
+  }
+
+  const sections: Array<[string, string | null]> = [
+    ['교훈', note.lesson],
+    ['증상', note.symptom],
+    ['원인', note.rootCause],
+    ['해결', note.resolution],
+    ['검증', note.verification],
+    ['재발 방지', note.prevention],
+  ];
+  for (const [title, body] of sections) {
+    if (body && body.trim()) {
+      lines.push('', `## ${title}`, '', body.trim());
+    }
+  }
+
+  if (note.referenceLinks.length) {
+    lines.push('', '## 참고', '');
+    for (const link of note.referenceLinks) {
+      if (!link.url) {
+        // 주소가 없는 줄(커밋 해시 등)은 그대로
+        lines.push(`- ${link.label}`);
+      } else if (link.label === link.url) {
+        // 라벨 없이 주소만 적힌 줄. 서버가 label 을 url 로 채워 주므로 그대로 쓰면 주소가 두 번 나온다
+        lines.push(`- ${link.url}`);
+      } else {
+        lines.push(`- ${link.label}: ${link.url}`);
+      }
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+};
+
+/**
+ * 클립보드에 넣는다. navigator.clipboard 는 보안 컨텍스트(https/localhost)에서만 있으므로,
+ * 없거나 거부되면 textarea + execCommand 로 떨어진다. 성공 여부를 boolean 으로 준다 —
+ * 실패했는데 "복사됨" 이 뜨면 사용자가 빈 클립보드를 붙여 넣게 된다.
+ */
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  try {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* 아래 예비 경로로 간다 */
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    // 화면 밖에 두되 focus 가 가능해야 한다. display:none 이면 선택이 안 된다.
+    ta.style.position = 'fixed';
+    ta.style.top = '-1000px';
+    ta.setAttribute('readonly', 'true');
+    document.body.appendChild(ta);
+    ta.select();
+    ta.setSelectionRange(0, text.length);
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+};

--- a/src/pages/AdminTroubleshooting.css
+++ b/src/pages/AdminTroubleshooting.css
@@ -472,3 +472,12 @@
     flex-direction: column;
   }
 }
+
+/* 상세 상단 도구줄 — '목록으로' 와 '전체 복사' */
+.ts-detail-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}

--- a/src/pages/AdminTroubleshootingDetail.tsx
+++ b/src/pages/AdminTroubleshootingDetail.tsx
@@ -1,16 +1,18 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { IonPage, IonContent, IonButton, IonSpinner, IonIcon } from '@ionic/react';
-import { arrowBackOutline } from 'ionicons/icons';
+import { arrowBackOutline, copyOutline, checkmarkOutline } from 'ionicons/icons';
 import { Helmet } from 'react-helmet';
 import CommonHeader from '../common/CommonHeader';
 import AdminSidebar from '../common/AdminSidebar';
 import { isAdminLoggedIn } from '../common/adminApi';
 import {
   TroubleshootingDetail,
+  copyToClipboard,
   fetchNote,
   formatOccurredOn,
   formatStamp,
+  noteToText,
   severityMeta,
 } from '../common/troubleshootingApi';
 import './AdminTroubleshooting.css';
@@ -44,6 +46,8 @@ const AdminTroubleshootingDetail: React.FC = () => {
   const [note, setNote] = useState<TroubleshootingDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
+  // '복사됨' / '복사 실패' 중 어느 쪽인지. 잠깐 보여주고 되돌린다.
+  const [copyState, setCopyState] = useState<'idle' | 'done' | 'failed'>('idle');
 
   useEffect(() => {
     if (!isAdminLoggedIn()) {
@@ -67,6 +71,21 @@ const AdminTroubleshootingDetail: React.FC = () => {
     load();
   }, [load]);
 
+  // 다른 기록으로 넘어가면 이전 화면의 '복사됨' 표시가 남지 않게 되돌린다
+  useEffect(() => {
+    setCopyState('idle');
+  }, [slug]);
+
+  const handleCopyAll = async () => {
+    if (!note) {
+      return;
+    }
+    const ok = await copyToClipboard(noteToText(note));
+    setCopyState(ok ? 'done' : 'failed');
+    // 실패는 조금 더 오래 남겨 둔다 — 놓치면 빈 클립보드를 붙여 넣게 된다
+    window.setTimeout(() => setCopyState('idle'), ok ? 1800 : 4000);
+  };
+
   const sev = severityMeta(note?.severity ?? null);
 
   return (
@@ -81,14 +100,29 @@ const AdminTroubleshootingDetail: React.FC = () => {
         <div className="ts-layout">
           <AdminSidebar />
           <div className="ts-main">
-            <IonButton
-              fill="clear"
-              size="small"
-              onClick={() => history.push('/admin/troubleshooting')}
-            >
-              <IonIcon slot="start" icon={arrowBackOutline} />
-              목록으로
-            </IonButton>
+            <div className="ts-detail-toolbar">
+              <IonButton
+                fill="clear"
+                size="small"
+                onClick={() => history.push('/admin/troubleshooting')}
+              >
+                <IonIcon slot="start" icon={arrowBackOutline} />
+                목록으로
+              </IonButton>
+
+              {/* 기록 전체를 마크다운 텍스트로 클립보드에 넣는다. Claude 에게 붙여 넣어
+                  참고시키는 용도라, 화면에 보이는 순서 그대로 절 제목을 붙여 뽑는다. */}
+              <IonButton
+                fill="outline"
+                size="small"
+                disabled={!note}
+                onClick={handleCopyAll}
+                color={copyState === 'failed' ? 'danger' : copyState === 'done' ? 'success' : undefined}
+              >
+                <IonIcon slot="start" icon={copyState === 'done' ? checkmarkOutline : copyOutline} />
+                {copyState === 'done' ? '복사됨' : copyState === 'failed' ? '복사 실패' : '전체 복사'}
+              </IonButton>
+            </div>
 
             {isLoading ? (
               <div className="ts-loading">


### PR DESCRIPTION
## 무엇

트러블슈팅 상세 화면 상단에 **전체 복사** 버튼. 기록 한 건을 마크다운 텍스트로 클립보드에 넣는다.

Claude 에게 붙여 넣어 참고시키려는 용도라, 화면 모양이 아니라 **읽는 쪽이 구조를 알아볼 수 있는 형태**로 뽑는다.

```
# <제목>

- 발생일: 2026.08.21
- 프로젝트: …
- 구성요소: …
- 심각도: medium
- 에러 코드: …
- 기술: …
- 태그: #a #b
- slug: …

## 교훈
## 증상
## 원인
## 해결
## 검증
## 재발 방지
## 참고
```

절 순서는 화면과 같게 맞췄다. 본문은 저장된 원문을 그대로 둔다 — 증상의 에러 메시지를 다듬으면 붙여 넣는 의미가 없어진다. 비어 있는 절은 제목만 남기지 않고 뺀다.

## 참고 링크 세 가지 모양

기록을 남기는 쪽이 사람이라 참고 줄의 모양이 섞여 있다. 셋을 구분한다.

| 저장된 줄 | 복사되는 줄 |
|---|---|
| `PR: https://github.com/…/pull/19` | `- PR: https://github.com/…/pull/19` |
| `머지 커밋: bee50aa` (주소 없음) | `- 머지 커밋: bee50aa` |
| `https://git.example.net/…` (라벨 없음) | `- https://git.example.net/…` |

세 번째가 이 PR 에서 고친 것이다. 서버가 라벨 없는 줄의 `label` 을 `url` 로 채워 주기 때문에 `- ${label}: ${url}` 로 그냥 쓰면 **같은 주소가 두 번** 나왔다. 검증 중에 클립보드 내용을 눈으로 보고 발견했다.

## 클립보드

`navigator.clipboard` 는 보안 컨텍스트(https/localhost)에서만 있으므로, 없거나 거부되면 `textarea` + `execCommand` 로 떨어진다.

**성공 여부를 실제로 확인한다.** 실패하면 '복사 실패' 를 4초간(성공은 1.8초) 띄운다. 실패했는데 '복사됨' 이 뜨면 사용자가 빈 클립보드를 붙여 넣게 되고, 그건 조용한 실패다.

## 검증

목 백엔드에 실제 기록 11건을 실어 헤드리스 Chrome 으로 **클립보드를 읽어** 대조했다. 버튼이 보이는지가 아니라 무엇이 들어갔는지를 본다.

| 확인한 것 | 결과 |
|---|---|
| 도구줄 | `목록으로` + `전체 복사` 두 개, 클릭 후 라벨이 `복사됨` 으로 바뀜 |
| 내용 대조 | 제목·slug·프로젝트 메타·증상 절·원인 절 존재 |
| 원문 보존 | 화면의 증상 원문이 복사본에 그대로 |
| 절 순서 | 화면 `[교훈 증상 원인 해결 검증 재발방지 참고]` == 복사본 |
| 빈 절 | 제목만 남은 절 없음 |
| 참고 세 형태 | 라벨 있는 링크 / 주소 없는 줄 / 라벨 없는 주소 각각 확인, 중복 없음 |
| 모바일 375 | 도구줄 버튼 2개 유지, 가로 넘침 없음 (375/375) |

12건 통과, 페이지 오류 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
