### PR TITLE
✨ Feat: 목록에서 기록 전체를 한 번에 복사

### DIFF
--- a/src/common/troubleshootingApi.ts
+++ b/src/common/troubleshootingApi.ts
@@ -252,3 +252,57 @@ export const copyToClipboard = async (text: string): Promise<boolean> => {
     return false;
   }
 };
+
+/**
+ * 조건에 맞는 기록을 본문까지 전부 받아온다. 목록의 '전체 복사' 가 쓴다.
+ *
+ * 목록 응답에는 본문이 없어서 건마다 상세를 부르면 N+1 이 된다. 서버가 한 번에 준다.
+ */
+export const fetchNotesForExport = async (
+  query: Omit<TroubleshootingQuery, 'page' | 'size'>
+): Promise<TroubleshootingDetail[]> => {
+  const params: Record<string, string> = {};
+  if (query.keyword) params.keyword = query.keyword;
+  if (query.project) params.project = query.project;
+  if (query.severity) params.severity = query.severity;
+  if (query.tag) params.tag = query.tag;
+
+  try {
+    const { data } = await adminApi.get<{ notes: TroubleshootingDetail[]; count: number }>(
+      `${BASE}/export`,
+      { params }
+    );
+    return data.notes ?? [];
+  } catch (error) {
+    throw new Error(messageOf(error, '기록을 가져오지 못했습니다.'));
+  }
+};
+
+/**
+ * 여러 건을 하나의 문서로 잇는다.
+ *
+ * 맨 위에 몇 건인지와 어떤 조건으로 뽑은 것인지를 적는다 — 붙여 넣은 쪽이 "이게 전부인가,
+ * 걸러진 것인가" 를 알아야 하기 때문이다. 기록 사이는 `---` 로 끊어 경계를 분명히 한다.
+ */
+export const notesToText = (
+  notes: TroubleshootingDetail[],
+  filter: Omit<TroubleshootingQuery, 'page' | 'size'> = {}
+): string => {
+  const conditions: string[] = [];
+  if (filter.keyword) conditions.push(`검색 '${filter.keyword}'`);
+  if (filter.project) conditions.push(`프로젝트 ${filter.project}`);
+  if (filter.severity) conditions.push(`심각도 ${filter.severity}`);
+  if (filter.tag) conditions.push(`태그 #${filter.tag}`);
+
+  const head = [
+    `# 트러블슈팅 기록 ${notes.length}건`,
+    '',
+    conditions.length ? `조건: ${conditions.join(' · ')}` : '조건: 전체',
+    '',
+  ].join('\n');
+
+  // noteToText 가 기록마다 '# 제목' 으로 시작하므로, 문서 제목과 섞이지 않게 한 단계 내린다
+  const body = notes.map((n) => noteToText(n).replace(/^#/gm, '##').trim()).join('\n\n---\n\n');
+
+  return `${head}\n${body}\n`;
+};

--- a/src/pages/AdminTroubleshooting.css
+++ b/src/pages/AdminTroubleshooting.css
@@ -481,3 +481,19 @@
   gap: 8px;
   flex-wrap: wrap;
 }
+
+/* 목록 머리말 오른쪽 버튼 묶음 — 전체 복사 + 새로고침 */
+.ts-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+  /* 좁은 화면에서는 머리말이 위아래로 쌓이므로 버튼을 왼쪽에 붙인다 */
+  .ts-head-actions {
+    width: 100%;
+  }
+}

--- a/src/pages/AdminTroubleshooting.tsx
+++ b/src/pages/AdminTroubleshooting.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { IonPage, IonContent, IonButton, IonSpinner, IonIcon, IonAlert } from '@ionic/react';
-import { refreshOutline, linkOutline } from 'ionicons/icons';
+import { refreshOutline, linkOutline, copyOutline, checkmarkOutline } from 'ionicons/icons';
 import { Helmet } from 'react-helmet';
 import CommonHeader from '../common/CommonHeader';
 import AdminSidebar from '../common/AdminSidebar';
 import { isAdminLoggedIn } from '../common/adminApi';
 import {
   TroubleshootingPage,
+  copyToClipboard,
   fetchNotes,
+  fetchNotesForExport,
   formatOccurredOn,
+  notesToText,
   severityMeta,
 } from '../common/troubleshootingApi';
 import './AdminTroubleshooting.css';
@@ -52,6 +55,9 @@ const AdminTroubleshooting: React.FC = () => {
   const [showAllTags, setShowAllTags] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
+  // 전체 복사: 서버에서 본문까지 받아오는 동안 기다려야 하므로 진행 상태를 따로 둔다
+  const [copyState, setCopyState] = useState<'idle' | 'working' | 'done' | 'failed'>('idle');
+  const [copiedCount, setCopiedCount] = useState(0);
 
   // 미로그인 시 관리자 로그인(/admin)으로 보낸다
   useEffect(() => {
@@ -91,6 +97,35 @@ const AdminTroubleshooting: React.FC = () => {
   const handleSearch = () => {
     setPage(0);
     setKeyword(keywordInput.trim());
+  };
+
+  /**
+   * 지금 걸린 조건에 맞는 기록 전체를 본문까지 텍스트로 복사한다.
+   * 보고 있는 페이지가 아니라 **조건에 맞는 전부**다 — 페이지를 넘겨가며 복사하게 만들지 않는다.
+   */
+  const handleCopyAll = async () => {
+    setCopyState('working');
+    try {
+      const notes = await fetchNotesForExport({ keyword, project, severity, tag });
+      if (notes.length === 0) {
+        setCopyState('failed');
+        setErrorMessage('복사할 기록이 없습니다.');
+        window.setTimeout(() => setCopyState('idle'), 2500);
+        return;
+      }
+      const ok = await copyToClipboard(notesToText(notes, { keyword, project, severity, tag }));
+      setCopiedCount(notes.length);
+      setCopyState(ok ? 'done' : 'failed');
+      if (!ok) {
+        setErrorMessage('클립보드에 넣지 못했습니다. 브라우저 권한을 확인해 주세요.');
+      }
+      // 실패는 조금 더 오래 남긴다 — 놓치면 빈 클립보드를 붙여 넣게 된다
+      window.setTimeout(() => setCopyState('idle'), ok ? 2200 : 4000);
+    } catch (error) {
+      setCopyState('failed');
+      setErrorMessage(error instanceof Error ? error.message : '기록을 가져오지 못했습니다.');
+      window.setTimeout(() => setCopyState('idle'), 4000);
+    }
   };
 
   /** 같은 값을 다시 누르면 해제된다 — 조건을 지우려고 드롭다운을 찾지 않게 */
@@ -156,10 +191,34 @@ const AdminTroubleshooting: React.FC = () => {
                   {result ? ` 전체 ${result.totalNotes}건.` : ''}
                 </p>
               </div>
-              <IonButton fill="outline" size="default" onClick={load} disabled={isLoading}>
-                <IonIcon slot="start" icon={refreshOutline} />
-                새로고침
-              </IonButton>
+              <div className="ts-head-actions">
+                {/* 조건에 맞는 기록 전체를 본문까지 한 번에 복사한다. 상세를 열지 않고
+                    Claude 에게 붙여 넣으려는 용도라 목록 화면에 둔다. */}
+                <IonButton
+                  fill="outline"
+                  size="default"
+                  onClick={handleCopyAll}
+                  disabled={isLoading || copyState === 'working' || rows.length === 0}
+                  color={copyState === 'failed' ? 'danger' : copyState === 'done' ? 'success' : undefined}
+                >
+                  {copyState === 'working' ? (
+                    <IonSpinner name="crescent" style={{ width: 16, height: 16 }} />
+                  ) : (
+                    <IonIcon slot="start" icon={copyState === 'done' ? checkmarkOutline : copyOutline} />
+                  )}
+                  {copyState === 'working'
+                    ? ' 모으는 중'
+                    : copyState === 'done'
+                      ? `${copiedCount}건 복사됨`
+                      : copyState === 'failed'
+                        ? '복사 실패'
+                        : '전체 복사'}
+                </IonButton>
+                <IonButton fill="outline" size="default" onClick={load} disabled={isLoading}>
+                  <IonIcon slot="start" icon={refreshOutline} />
+                  새로고침
+                </IonButton>
+              </div>
             </header>
 
             {/* 심각도 요약 겸 필터. 숫자는 전체 기준이라 필터를 걸어도 변하지 않는다 */}


### PR DESCRIPTION
## 무엇

목록 머리말에 **전체 복사**. 상세를 열지 않고 조건에 맞는 기록 전체를 텍스트로 복사한다.

백엔드: kingle1024/nklcbdty-service#227 (먼저 머지)

## 결정한 것들

**보고 있는 페이지가 아니라 조건에 맞는 전부를 복사한다.** 페이지를 넘겨가며 여러 번 복사하게 만들지 않는다. 서버의 `/export` 가 본문까지 한 번에 주므로 건마다 상세를 부르는 N+1 이 없다.

**맨 위에 건수와 조건을 적는다.**

```
# 트러블슈팅 기록 11건

조건: 전체
```

```
# 트러블슈팅 기록 1건

조건: 심각도 critical
```

붙여 넣은 쪽이 "이게 전부인가, 걸러진 것인가" 를 알아야 한다. 조건 없이 뽑은 것과 필터를 걸어 뽑은 것이 구별되지 않으면, 받은 쪽이 없는 사실을 없다고 단정하게 된다.

**기록 제목을 한 단계 내린다.** `noteToText` 는 기록마다 `# 제목` 으로 시작하는데, 여러 건을 이으면 문서 제목과 같은 단계가 된다. `#` → `##` 로 내려 절 제목이 `###` 이 되고 계층이 유지된다. 기록 사이는 `---` 로 끊는다.

**진행 상태를 보여준다.** 서버에서 모으는 동안 '모으는 중' 스피너, 끝나면 'N건 복사됨'. 복사할 기록이 없거나 클립보드에 넣지 못하면 사유를 알린다 — 조용히 실패하면 빈 클립보드를 붙여 넣는다.

## 검증

목 백엔드에 실제 기록 11건을 실어 헤드리스 Chrome 으로 **클립보드를 읽어** 대조. **15건 통과**, 페이지 오류 없음.

| 확인한 것 | 결과 |
|---|---|
| 머리말 버튼 | `전체 복사` + `새로고침` |
| 건수 머리말 | `# 트러블슈팅 기록 11건` (화면 카드 11건과 일치) |
| 조건 표기 | 조건 없으면 `조건: 전체` |
| 라벨 | 클릭 후 `11건 복사됨` |
| 기록 경계 | 제목 11개, 구분선 10개 |
| 요약이 아닌 본문 | 59,385자, `### 증상` / `### 원인` 존재 |
| 계층 | 기록 제목 `##`, 절 제목 `###` |
| 조건 걸었을 때 | `조건: … 심각도 critical`, 화면 1건 = 복사 1건, 본문 유지 |
| 모바일 375 | 버튼 2개 유지, 가로 넘침 없음 (375/375) |

검증 중에 제 검사 두 건이 틀렸던 것을 고쳤다 — 제목을 한 단계 내리면서 절 제목이 `### 증상` 이 되는데 검사는 `## 증상` 을 찾고 있었다. 코드가 아니라 검사가 틀린 경우였고, 클립보드 실물을 출력해 봐서 구분됐다.

## 규모에 대한 메모

지금 11건이 약 59KB다. 기록이 수십 건으로 늘면 한 번에 붙여 넣기엔 커지므로, 그때는 조건을 걸어 잘라 복사하는 쪽이 맞다. 그래서 조건이 머리말에 남게 해뒀다. 서버 쪽 상한은 500건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “전체 복사” option to export all troubleshooting notes matching the current filters.
  * Exported notes are formatted as a Markdown document with result counts, applied filters, and separated note content.
  * Added progress, success, and failure feedback during copying.
  * Improved responsive layout for header actions on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->