### PR TITLE
✨ Feat: 모바일 메인에서 필터를 열 수 있는 버튼 추가

### DIFF
--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -138,6 +138,14 @@ label {
   border-radius: var(--radius-lg);
 }
 
+/* 모바일 전용 요소 — 데스크탑에서는 숨긴다 */
+.mobile-filter-toggle,
+.filter-backdrop,
+.filter-panel-header,
+.filter-apply {
+  display: none;
+}
+
 /* 반응형 디자인 */
 @media (min-width: 768px) {
   .mySwiper {
@@ -162,6 +170,113 @@ label {
     padding: 12px;
   }
   .left-aside {
-    display: none; /* 모바일에서는 기본적으로 숨김 */
+    display: none; /* 모바일에서는 기본적으로 숨김, 필터 버튼으로 연다 */
+  }
+
+  /* 목록 위에 뜨는 필터 버튼 */
+  .mobile-filter-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    padding: 8px 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background-color: var(--surface);
+    color: var(--text-strong);
+    font-size: 14px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    box-shadow: var(--shadow-card);
+  }
+
+  .mobile-filter-toggle:active {
+    background-color: var(--surface-field);
+  }
+
+  .mobile-filter-badge {
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: var(--radius-pill);
+    background-color: var(--brand-primary);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 18px;
+    text-align: center;
+  }
+
+  /* 시트 뒤 배경 */
+  .filter-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background-color: rgba(25, 31, 40, 0.45);
+    z-index: 1000;
+  }
+
+  /* 열린 필터 시트 */
+  .left-aside.is-open {
+    display: block;
+    position: fixed;
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: auto;
+    max-height: 82vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    border: none;
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    box-shadow: 0 -4px 20px rgba(25, 31, 40, 0.18);
+    padding-bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    z-index: 1001;
+  }
+
+  .left-aside.is-open .filter-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  }
+
+  .left-aside.is-open .filter-panel-header h2 {
+    margin: 0;
+    font-size: 18px;
+  }
+
+  .filter-close {
+    border: none;
+    background: none;
+    padding: 4px 8px;
+    font-size: 16px;
+    line-height: 1;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  /* 시트 하단에 고정되는 적용 버튼 */
+  .left-aside.is-open .filter-apply {
+    display: block;
+    position: sticky;
+    bottom: 0;
+    width: 100%;
+    margin-top: 20px;
+    padding: 14px;
+    border: none;
+    border-radius: var(--radius-md);
+    background-color: var(--brand-primary);
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .left-aside.is-open .filter-apply:active {
+    background-color: var(--brand-primary-pressed);
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -78,6 +78,15 @@ const Home: React.FC = () => {
   // State to manage the visibility of categories
   const [visibleCategories, setVisibleCategories] = useState<Record<string, boolean>>({});
 
+  // 모바일 필터 시트 열림 여부 (PC 는 사이드바가 항상 보이므로 쓰이지 않는다)
+  const [isFilterOpen, setIsFilterOpen] = useState<boolean>(false);
+
+  // 필터 버튼 배지 숫자 — 기본값에서 벗어난 필터 개수
+  const activeFilterCount =
+    Object.values(filters.categories).reduce((sum, list) => sum + list.length, 0) +
+    (filters.personalHistory.start !== 0 || filters.personalHistory.end !== 10 ? 1 : 0) +
+    (filters.includeNoExperience ? 0 : 1);
+
   // Function to handle filter change
   const handleFilterChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value, checked, name } = event.target;
@@ -213,7 +222,34 @@ const Home: React.FC = () => {
         </SwiperSlide>
       </Swiper> */}
         <div className="container">
-          <aside className="left-aside">
+          <button
+            type="button"
+            className="mobile-filter-toggle"
+            onClick={() => setIsFilterOpen(true)}
+            aria-expanded={isFilterOpen}
+            aria-controls="job-filter-panel"
+          >
+            <span aria-hidden="true">&#9776;</span>
+            필터
+            {activeFilterCount > 0 && <span className="mobile-filter-badge">{activeFilterCount}</span>}
+          </button>
+
+          {isFilterOpen && (
+            <div className="filter-backdrop" onClick={() => setIsFilterOpen(false)} />
+          )}
+
+          <aside id="job-filter-panel" className={`left-aside${isFilterOpen ? ' is-open' : ''}`}>
+            <div className="filter-panel-header">
+              <h2>필터</h2>
+              <button
+                type="button"
+                className="filter-close"
+                onClick={() => setIsFilterOpen(false)}
+                aria-label="필터 닫기"
+              >
+                &#10005;
+              </button>
+            </div>
             <h2>직군</h2>
             <form>
               {categoriesData.map((categoryData) => {
@@ -303,6 +339,10 @@ const Home: React.FC = () => {
                 />
               </div>
             </div>
+
+            <button type="button" className="filter-apply" onClick={() => setIsFilterOpen(false)}>
+              결과 보기
+            </button>
           </aside>
           <main className="content">
             <ListContainer filters={filters} />


### PR DESCRIPTION
## 문제

모바일 메인 페이지에서 필터 버튼이 보이지 않는다.

`Home.css` 의 `@media (max-width: 767px)` 에서 `.left-aside { display: none }` 으로 필터 사이드바를 숨기기만 하고, 이를 다시 열 수 있는 UI 가 없었다. 버튼이 깨진 게 아니라 애초에 존재하지 않아서, **모바일 사용자는 직군·경력 필터를 전혀 쓸 수 없는 상태**였다.

## 변경

- 목록 위에 모바일 전용 `필터` 버튼 추가 — 적용된 필터 개수를 배지로 표시
- 버튼을 누르면 기존 사이드바가 **바텀시트**로 올라옴
  - 백드롭 탭 / `✕` / 하단 고정 `결과 보기` 버튼으로 닫힘
  - `max-height: 82vh` + 내부 스크롤, `env(safe-area-inset-bottom)` 반영
- 필터 상태(`filters`)와 핸들러는 그대로 재사용 — PC 사이드바와 완전히 동일하게 동작
- 데스크탑(`>=768px`) 렌더링 결과는 변화 없음 (새 요소는 전부 `display: none`)

## 검증

`npx tsc --noEmit` 통과, dev server 컴파일 에러 없음. 헤드리스 브라우저로 확인:

| 확인 항목 | 결과 |
|---|---|
| 375px 필터 버튼 노출 | ✅ |
| 버튼 → 바텀시트 열림 (`fixed`, `bottom:0`, `z-index:1001`) | ✅ |
| 백드롭 탭으로 닫힘 | ✅ |
| `결과 보기` 로 닫힘 | ✅ |
| 필터 개수 배지 증감 | ✅ |
| 1280px 데스크탑 (사이드바 `sticky`, 모바일 요소 `none`) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile filter button with an active-filter count badge.
  * Filters now open in a bottom-sheet interface with backdrop, close, scrolling, and apply controls.
  * Added mobile-friendly spacing and layering for easier filter navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->